### PR TITLE
Proceed on tif-reproject criteria errors

### DIFF
--- a/preprocessors/tif-reproject.preprocessor.js
+++ b/preprocessors/tif-reproject.preprocessor.js
@@ -16,13 +16,13 @@ module.exports.criteria = function(filepath, info, callback) {
   var projection;
 
   try { ds = gdal.open(filepath); }
-  catch (err) { return callback(err); }
+  catch (err) { return callback(null, false); }
 
   try {
     sm = srs.parse(sm.toProj4());
     projection = srs.parse(ds.srs.toProj4());
   }
-  catch (err) { return callback(err); }
+  catch (err) { return callback(null, false); }
 
   if (projection === sm) callback(null, false);
   else callback(null, true);


### PR DESCRIPTION
Adjusts `tif-reproject.preprocessor` such that if SRS comparison fails, the preprocessorcerer does not attempt to reproject the file.

SRS comparison is janky and could use more attention -- node-gdal seems to be able to `.toProj4()` some projections and not others, which it may still be able to `.toWKT()`.

@springmeyer I wonder if you have any thoughts on this: would it be better to
- continue performing SRS comparison as I'm doing here (by comparing `srs.parsed` strings), or
- compare node-gdal objects: `ds.srs.isSame(gdal.SpatialReference.fromEPSG(3857))`?