### PR TITLE
Improved node-wmshp

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "queue-async": "^1.0.7",
     "split": "^0.3.3",
     "srs": "^0.4.6",
-    "wmshp": "0.0.5",
+    "wmshp": "0.1.0",
     "wmtiff": "0.1.1"
   },
   "jshintConfig": {

--- a/preprocessors/shp-reproject.preprocessor.js
+++ b/preprocessors/shp-reproject.preprocessor.js
@@ -3,7 +3,10 @@ var wmshp = require('wmshp');
 var gdal = require('gdal');
 
 module.exports = function(infile, outfile, callback) {
-  wmshp(infile, outfile, callback);
+  try { wmshp(infile, outfile); }
+  catch (err) { return callback(err); }
+
+  callback();
 };
 
 module.exports.description = 'Reproject shapefile to EPSG:3857';


### PR DESCRIPTION
Bump node-wmshp after [a breaking api change](https://github.com/mapbox/node-wmshp/pull/8). Improves cropping logic significantly and supports reprojection that includes datum transformations.