### PR TITLE
Partition rasters less generously than other untiled formats

### DIFF
--- a/parts/bySize.js
+++ b/parts/bySize.js
@@ -2,12 +2,15 @@ module.exports = function splitBySize(filepath, info, callback) {
   var max = 50;
   var mb = info.size / 1024 / 1024;
   var pretiled = ['serialtiles', 'tilejson', 'mbtiles'];
-  var untiled = ['zip', 'gpx', 'kml', 'geojson', 'csv', 'tif'];
+  var untiled = ['zip', 'gpx', 'kml', 'geojson', 'csv'];
+  var raster = ['tif'];
 
   if (pretiled.indexOf(info.filetype) !== -1) {
     callback(null, Math.min(max, Math.ceil(mb / 100)));
   } else if (untiled.indexOf(info.filetype) !== -1) {
     callback(null, Math.min(max, Math.ceil(mb / 10)));
+  } else if (raster.indexOf(info.filetype) !== -1) {
+    callback(null, Math.min(max, Math.ceil(mb / 100)));
   } else {
     callback(null, 1);
   }

--- a/test/bySize.test.js
+++ b/test/bySize.test.js
@@ -192,7 +192,7 @@ test('[parts bySize] csv split per 10MB', function(assert) {
 
 test('[parts bySize] tif split per 10MB', function(assert) {
   var mbs = 25;
-  var expected = Math.ceil(mbs / 10);
+  var expected = Math.ceil(mbs / 100);
   var info = {
     size: mbs * 1024 * 1024,
     filetype: 'tif'


### PR DESCRIPTION
In tests TIFs tile more rapidly with fewer/bigger partition chunks.