### PR TITLE
Convert GPX/KML to geojson

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    "indent": [2, 2],
+    "quotes": [2, "single"],
+    "no-console": [0],
+    "semi": [2, "always"]
+  },
+  "env": {
+      "node": true
+  },
+  "globals": {
+      "process": true,
+      "module": true,
+      "require": true
+  },
+  "extends": "eslint:recommended"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules
 preprocessors/test*
 test/fixtures/*.aux.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
  - "0.10"
- - "0.12"
+ - "4.2.3"
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+ - Updated mapnik to 3.5.0
+
 ## 0.10.2
 
  - Packaged without 68 MB test data

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bytetiff": "~0.3.0",
     "gdal": "~0.8.0",
     "mapbox-file-sniff": "~0.4.0",
-    "mapnik-omnivore": "~7.1.1",
+    "mapnik-omnivore": "~7.3.0",
     "mapnik": "~3.5.0",
     "mkdirp": "^0.5.0",
     "mbtiles": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bytetiff": "~0.3.0",
     "gdal": "~0.8.0",
     "mapbox-file-sniff": "~0.4.0",
+    "mapnik-omnivore": "~7.1.1",
     "mapnik": "~3.5.0",
     "mkdirp": "^0.5.0",
     "mbtiles": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprocessorcerer",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "bytetiff": "~0.3.0",
     "gdal": "~0.8.0",
     "mapbox-file-sniff": "~0.4.0",
-    "mapnik": "~3.4.11",
+    "mapnik": "~3.5.0",
     "mkdirp": "^0.5.0",
     "mbtiles": "^0.8.0",
     "queue-async": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bytetiff": "~0.3.0",
     "gdal": "~0.8.0",
     "mapbox-file-sniff": "~0.4.0",
-    "mapnik-omnivore": "~7.3.0",
+    "mapnik-omnivore": "~7.4.0",
     "mapnik": "~3.5.0",
     "mkdirp": "^0.5.0",
     "mbtiles": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "pretest": "jshint index.js bin parts preprocessors test && jscs index.js bin parts preprocessors test",
+    "pretest": "jshint index.js bin parts preprocessors test && eslint index.js bin parts preprocessors test && jscs index.js bin parts preprocessors test",
     "test": "tape test/*.test.js",
     "coverage": "istanbul cover tape test/*.test.js && coveralls < ./coverage/lcov.info"
   },
@@ -23,13 +23,15 @@
   "homepage": "https://github.com/mapbox/preprocessorcerer",
   "devDependencies": {
     "concat-stream": "^1.4.8",
+    "eslint": "^1.6.0",
     "jscs": "^1.10.0",
     "jshint": "^2.6.0",
     "tape": "^3.4.0",
     "tilelive": "^5.7.0",
     "istanbul": "~0.3.17",
     "coveralls": "~2.11.2",
-    "checksum": "^0.1.1"
+    "checksum": "^0.1.1",
+    "rimraf": "^2.5.2"
   },
   "dependencies": {
     "bytetiff": "~0.3.0",
@@ -55,6 +57,7 @@
     "preset": "airbnb",
     "requireCamelCaseOrUpperCaseIdentifiers": null,
     "disallowMultipleVarDecl": true,
-    "requireMultipleVarDecl": null
+    "requireMultipleVarDecl": null,
+    "validateLineBreaks": null
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprocessorcerer",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/parts/mbtiles-byTiles.js
+++ b/parts/mbtiles-byTiles.js
@@ -18,11 +18,15 @@ module.exports = function splitBySize(filepath, info, callback) {
         }
         else if (err) return callback(err);
 
-        var maxTilesPerJob = 100000;
-        var result = tilesResult.count + gridsResult.count;
-        if (!result) return callback(new Error('no tiles or grids'));
+        src.close(function(err) {
+          if (err) return callback(err);
+          src = null;
+          var maxTilesPerJob = 100000;
+          var result = tilesResult.count + gridsResult.count;
+          if (!result) return callback(new Error('no tiles or grids'));
 
-        callback(null, Math.min(50, Math.ceil(result / maxTilesPerJob)));
+          callback(null, Math.min(50, Math.ceil(result / maxTilesPerJob)));
+        });
       });
     });
   });

--- a/preprocessors/geojson-bom.preprocessor.js
+++ b/preprocessors/geojson-bom.preprocessor.js
@@ -32,7 +32,10 @@ module.exports.criteria = function(infile, info, callback) {
     fs.read(fd, buf, 0, 3, 0, function(err) {
       if (err) return callback(err);
       var strip = buf[0] === 0xef && buf[1] === 0xbb && buf[2] == 0xbf;
-      callback(null, strip);
+      fs.close(fd, function(err) {
+        if (err) return callback(err);
+        callback(null, strip);
+      });
     });
   });
 };

--- a/preprocessors/index.js
+++ b/preprocessors/index.js
@@ -10,7 +10,9 @@ var preprocessors = [
   'tif-reproject.preprocessor',
   'shp-index.preprocessor',
   'geojson-bom.preprocessor',
-  'spatial-index.preprocessor'
+  'spatial-index.preprocessor',
+  'togeojson-kml.preprocessor',
+  'togeojson-gpx.preprocessor'
 ];
 
 // Loads each *.preprocessor.js file and builds an array of them

--- a/preprocessors/shp-index.preprocessor.js
+++ b/preprocessors/shp-index.preprocessor.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 var mapnik = require('mapnik');
-var shapeindex = path.resolve(mapnik.module_path, 'shapeindex');
+var shapeindex = path.resolve(mapnik.module_path, 'shapeindex' + (process.platform === 'win32' ? '.exe' : ''));
 if (!fs.existsSync(shapeindex)) {
   throw new Error('shapeindex does not exist at ' + shapeindex);
 }

--- a/preprocessors/spatial-index.preprocessor.js
+++ b/preprocessors/spatial-index.preprocessor.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 var mapnik = require('mapnik');
-var mapnik_index = path.resolve(mapnik.module_path, 'mapnik-index' + (process.platform === 'win32' ? '.exe' : ''));
+var mapnik_index = path.resolve(mapnik.module_path, 'mapnik-index');
 if (!fs.existsSync(mapnik_index)) {
   throw new Error('mapnik-index does not exist at ' + mapnik_index);
 }
@@ -34,6 +34,7 @@ module.exports = function(infile, outdir, callback) {
         .on('exit', function() {
           // If error printed to --validate-features log
           if (data.indexOf('Error') != -1) {
+            console.log(data);
             callback('Invalid geojson feature');
           }
           else callback();

--- a/preprocessors/spatial-index.preprocessor.js
+++ b/preprocessors/spatial-index.preprocessor.js
@@ -34,7 +34,6 @@ module.exports = function(infile, outdir, callback) {
         .on('exit', function() {
           // If error printed to --validate-features log
           if (data.indexOf('Error') != -1) {
-            console.log(data);
             callback('Invalid geojson feature');
           }
           else callback();

--- a/preprocessors/spatial-index.preprocessor.js
+++ b/preprocessors/spatial-index.preprocessor.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 var mapnik = require('mapnik');
-var mapnik_index = path.resolve(mapnik.module_path, 'mapnik-index');
+var mapnik_index = path.resolve(mapnik.module_path, 'mapnik-index' + (process.platform === 'win32' ? '.exe' : ''));
 if (!fs.existsSync(mapnik_index)) {
   throw new Error('mapnik-index does not exist at ' + mapnik_index);
 }

--- a/preprocessors/tif-reproject.preprocessor.js
+++ b/preprocessors/tif-reproject.preprocessor.js
@@ -27,6 +27,9 @@ module.exports.criteria = function(filepath, info, callback) {
   }
   catch (err) { return callback(err); }
 
+  ds.close();
+  ds = null;
+
   if (projection === sm) callback(null, false);
   else callback(null, true);
 };

--- a/preprocessors/tif-toBytes.preprocessor.js
+++ b/preprocessors/tif-toBytes.preprocessor.js
@@ -21,6 +21,10 @@ module.exports.criteria = function(filepath, info, callback) {
   try { band = ds.bands.get(1); }
   catch (err) { return callback(err); }
 
-  if (band.dataType === gdal.GDT_UInt16) return callback(null, true);
-  callback(null, false);
+  var is16 = band.dataType === gdal.GDT_UInt16;
+
+  ds.close();
+  ds = null;
+
+  callback(null, is16);
 };

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -1,0 +1,72 @@
+var gdal = require('gdal');
+var mkdirp = require('mkdirp');
+var path = require('path');
+
+//disable in production
+//gdal.verbose();
+
+module.exports = function(infile, outdirectory, callback) {
+
+  mkdirp(outdirectory, function(err) {
+    if (err) return callback(err);
+
+    try {
+      var wgs84 = gdal.SpatialReference.fromEPSG(4326);
+      var ds_gpx = gdal.open(infile);
+      var full_feature_cnt = 0;
+
+      ds_gpx.layers.forEach(function(lyr_gpx) {
+        var feat_cnt = lyr_gpx.features.count(true);
+        if (feat_cnt === 0) {
+          return;
+        }
+
+        var lyr_name = lyr_gpx.name;
+        var out_name = path.join(outdirectory, lyr_name);
+        var out_ds = gdal.open(out_name, 'w', 'GeoJSON');
+        var geojson = out_ds.layers.create(lyr_name, wgs84, lyr_gpx.geomType);
+        lyr_gpx.features.forEach(function(gpx_feat) {
+          //skip null or empty geometries
+          var geom = gpx_feat.getGeometry();
+          if (!geom) {
+            return;
+          } else {
+            if (geom.isEmpty()) {
+              return;
+            }
+
+            if (!geom.isValid()) {
+              return;
+            }
+          }
+
+          geojson.features.add(gpx_feat);
+          full_feature_cnt++;
+        });
+
+        geojson.flush();
+        out_ds.flush();
+        out_ds.close();
+      });
+
+      ds_gpx.close();
+      if (full_feature_cnt === 0) {
+        return callback(new Error('GPX does not contain any valid features.'));
+      }
+    }
+    catch (err) {
+      return callback(err);
+    }
+
+    callback();
+  });
+};
+
+module.exports.description = 'Convert GPX to GeoJSON';
+
+module.exports.criteria = function(filepath, info, callback) {
+
+  if (info.filetype !== 'gpx') return callback(null, false);
+
+  callback(null, true);
+};

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -16,6 +16,11 @@ module.exports = function(infile, outdirectory, callback) {
       var full_feature_cnt = 0;
 
       ds_gpx.layers.forEach(function(lyr_gpx) {
+        //drop point layers as they can get really huge
+        if (lyr_gpx.name === 'track_points' || lyr_gpx.name === 'route_points') {
+          return;
+        }
+
         var feat_cnt = lyr_gpx.features.count(true);
         if (feat_cnt === 0) {
           return;

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -1,6 +1,7 @@
 var gdal = require('gdal');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
+var queue = require('queue-async');
 var spawn = require('child_process').spawn;
 var path = require('path');
 var digest = require('mapnik-omnivore').digest;
@@ -17,6 +18,7 @@ module.exports = function(infile, outdirectory, callback) {
   mkdirp(outdirectory, function(err) {
     if (err) return callback(err);
 
+    var geojson_files = [];
     var ds_gpx;
     var full_feature_cnt = 0;
     var wgs84 = gdal.SpatialReference.fromEPSG(4326);
@@ -81,10 +83,7 @@ module.exports = function(infile, outdirectory, callback) {
       geojson = null;
       out_ds = null;
 
-      // create mapnik index for each geojson layer
-      createIndex(out_name, function(err) {
-        if (err) return callback(err);
-      });
+      geojson_files.push(out_name);
     });
 
     ds_gpx.close();
@@ -95,11 +94,25 @@ module.exports = function(infile, outdirectory, callback) {
     // Create metadata file for original gpx source
     var metadatafile = path.join(outdirectory, '/metadata.json');
     digest(infile, function(err, metadata) {
+      if (err) return callback(err);
       fs.writeFile(metadatafile, JSON.stringify(metadata), function(err) {
+        if (err) return callback(err);
+        return createIndices(callback);
+      });
+    });
+
+    function createIndices(callback) {
+      // create mapnik index for each geojson layer
+      var q = queue();
+      geojson_files.forEach(function(gj) {
+        q.defer(createIndex, gj);
+      });
+
+      q.awaitAll(function(err) {
         if (err) return callback(err);
         return callback();
       });
-    });
+    }
 
     function createIndex(layerfile, callback) {
       // Finally, create an .index file in the output dir

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -85,19 +85,19 @@ module.exports = function(infile, outdirectory, callback) {
       });
     });
 
-    function createIndex(layerfile, callback) { 
-    // Finally, create an .index file in the output dir
-    // mapnik-index will automatically add ".index" to the end of the original filename
-    var data = '';
-    var p = spawn(mapnik_index, [layerfile, '--validate-features'])
-      .once('error', callback)
-      .on('exit', function() {
-        // If error printed to --validate-features log
-        if (data.indexOf('Error') != -1) {
-          callback('Invalid geojson feature');
-        }
-        else callback();
-      });
+    function createIndex(layerfile, callback) {
+      // Finally, create an .index file in the output dir
+      // mapnik-index will automatically add ".index" to the end of the original filename
+      var data = '';
+      var p = spawn(mapnik_index, [layerfile, '--validate-features'])
+        .once('error', callback)
+        .on('exit', function() {
+          // If error printed to --validate-features log
+          if (data.indexOf('Error') != -1) {
+            callback('Invalid geojson feature');
+          }
+          else callback();
+        });
 
       p.stderr.on('data', function(d) {
         d.toString();

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -115,28 +115,38 @@ module.exports = function(infile, outdirectory, callback) {
     }
 
     function createIndex(layerfile, callback) {
-      // Finally, create an .index file in the output dir
+      // Finally, create an .index file in the output dir (if layer is greater than index_worthy_size).
       // mapnik-index will automatically add ".index" to the end of the original filename
-      var data = '';
-      var p = spawn(mapnik_index, [layerfile, '--validate-features'])
-        .once('error', callback)
-        .on('exit', function() {
-          // If error printed to --validate-features log
-          if (data.indexOf('Error') != -1) {
-            callback(data);
-          }
-          else callback();
-        });
+      fs.stat(layerfile, function(err, stats) {
+        if (err) return callback(err);
 
-      p.stderr.on('data', function(d) {
-        d.toString();
-        data += d;
+        // check size is warrants creating an index
+        if (stats.size >= module.exports.index_worthy_size) {
+          var data = '';
+          var p = spawn(mapnik_index, [layerfile, '--validate-features'])
+            .once('error', callback)
+            .on('exit', function() {
+              // If error printed to --validate-features log
+              if (data.indexOf('Error') != -1) {
+                return callback(data);
+              }
+              else return callback();
+            });
+
+          p.stderr.on('data', function(d) {
+            d.toString();
+            data += d;
+          });
+        } else {
+          return callback();
+        }
       });
     }
   });
 };
 
 module.exports.description = 'Convert GPX to GeoJSON';
+module.exports.index_worthy_size = 10 * 1024 * 1024; // 10 MB
 
 module.exports.criteria = function(filepath, info, callback) {
 

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -124,23 +124,31 @@ module.exports = function(infile, outdirectory, callback) {
     }
 
     function createIndex(layerfile, callback) {
-      // Finally, create an .index file in the output dir
+      // Finally, create an .index file in the output dir (if layer is greater than index_worthy_size).
       // mapnik-index will automatically add ".index" to the end of the original filename
-      var data = '';
-      var p = spawn(mapnik_index, [layerfile, '--validate-features'])
-        .once('error', callback)
-        .on('exit', function() {
-          // If error printed to --validate-features log
-          if (data.indexOf('Error') != -1) {
-            console.log(data);
-            callback(data);
-          }
-          else callback();
-        });
+      fs.stat(layerfile, function(err, stats) {
+        if (err) return callback(err);
 
-      p.stderr.on('data', function(d) {
-        d.toString();
-        data += d;
+        // check size is warrants creating an index
+        if (stats.size >= module.exports.index_worthy_size) {
+          var data = '';
+          var p = spawn(mapnik_index, [layerfile, '--validate-features'])
+            .once('error', callback)
+            .on('exit', function() {
+              // If error printed to --validate-features log
+              if (data.indexOf('Error') != -1) {
+                return callback(data);
+              }
+              else return callback();
+            });
+
+          p.stderr.on('data', function(d) {
+            d.toString();
+            data += d;
+          });
+        } else {
+          return callback();
+        }
       });
     }
   });
@@ -179,3 +187,4 @@ function layername_count(ds) {
 
 //expose this as ENV option?
 module.exports.max_layer_count = 15;
+module.exports.index_worthy_size = 10 * 1024 * 1024; // 10 MB

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -1,0 +1,118 @@
+var gdal = require('gdal');
+var mkdirp = require('mkdirp');
+var path = require('path');
+var util = require('util');
+
+//disable in production
+//gdal.verbose();
+
+module.exports = function(infile, outdirectory, callback) {
+
+  mkdirp(outdirectory, function(err) {
+    if (err) return callback(err);
+
+    try {
+      var wgs84 = gdal.SpatialReference.fromEPSG(4326);
+      var ds_kml = gdal.open(infile);
+      var lyr_cnt = ds_kml.layers.count();
+      var full_feature_cnt = 0;
+
+      if (lyr_cnt < 1) {
+        ds_kml.close();
+        return callback(new Error('KML does not contain any layers.'));
+      }
+
+      if (lyr_cnt > module.exports.max_layer_count) {
+        ds_kml.close();
+        return callback(new Error(util.format('%d layers found. Maximum of %d layers allowed.', lyr_cnt, module.exports.max_layer_count)));
+      }
+
+      var duplicate_lyr_msg = layername_count(ds_kml);
+      if (duplicate_lyr_msg) {
+        ds_kml.close();
+        return callback(new Error(duplicate_lyr_msg));
+      }
+
+      ds_kml.layers.forEach(function(lyr_kml) {
+        var feat_cnt = lyr_kml.features.count(true);
+        if (feat_cnt === 0) {
+          return;
+        }
+
+        //strip kml from layer name. features at the root get the KML filename as layer name
+        var lyr_name = lyr_kml.name
+          .replace(/.kml/gi, '')
+          .replace(/[ \\/&?]/g, '_')
+          .replace(/[();:,\]\[{}]/g, '');
+        var out_name = path.join(outdirectory, lyr_name);
+        var out_ds = gdal.open(out_name, 'w', 'GeoJSON');
+        var geojson = out_ds.layers.create(lyr_name, wgs84, lyr_kml.geomType);
+        lyr_kml.features.forEach(function(kml_feat) {
+          var geom = kml_feat.getGeometry();
+          if (!geom) {
+            return;
+          } else {
+            if (geom.isEmpty()) {
+              return;
+            }
+
+            if (!geom.isValid()) {
+              return;
+            }
+          }
+
+          geojson.features.add(kml_feat);
+          full_feature_cnt++;
+        });
+
+        geojson.flush();
+        out_ds.flush();
+        out_ds.close();
+      });
+
+      ds_kml.close();
+      if (full_feature_cnt === 0) {
+        return callback(new Error('KML does not contain any valid features'));
+      }
+    }
+    catch (err) {
+      return callback(err);
+    }
+
+    callback();
+  });
+};
+
+module.exports.description = 'Convert KML to GeoJSON';
+
+module.exports.criteria = function(filepath, info, callback) {
+
+  if (info.filetype !== 'kml') return callback(null, false);
+
+  callback(null, true);
+};
+
+function layername_count(ds) {
+  var lyr_name_cnt = {};
+  ds.layers.forEach(function(lyr) {
+    var lyr_name = lyr.name;
+    if (lyr_name in lyr_name_cnt) {
+      lyr_name_cnt[lyr_name]++;
+    } else {
+      lyr_name_cnt[lyr_name] = 1;
+    }
+  });
+
+  var err = '';
+  for (var name in lyr_name_cnt) {
+    var cnt = lyr_name_cnt[name];
+    if (cnt > 1) {
+      err += util.format('%s[%s] found %d times', err.length > 0 ? ', ' : '', name, cnt);
+    }
+  }
+
+  return err.length > 0 ? 'Duplicate layer names! ' + err : null;
+}
+
+//expose this as ENV option?
+module.exports.max_layer_count = 15;

--- a/test/end2end.test.js
+++ b/test/end2end.test.js
@@ -13,7 +13,15 @@ var MBtiles = require('mbtiles');
 // with random names will litter the fixture directory
 var fixtureDir = path.resolve(__dirname, 'fixtures', 'end2end');
 var tmpdir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
-var cmd = ['cp -r', fixtureDir, tmpdir].join(' ');
+var copy_cmd = 'cp -r';
+if (process.platform === 'win32') {
+  //during tests %PATH% env var is completely stripped. add Windows system dir back to get xcopy
+  process.env.Path += ';' + path.join(process.env.windir, 'system32');
+  copy_cmd = 'xcopy /s /y';
+  tmpdir += '\\';
+}
+
+var cmd = [copy_cmd, fixtureDir, tmpdir].join(' ');
 exec(cmd, function(err) {
   if (err) throw err;
 

--- a/test/fixtures/gpx/fail-corrupted-file.gpx
+++ b/test/fixtures/gpx/fail-corrupted-file.gpx
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="ExpertGPS 1.1 - http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+  <trk>
+    <trkseg>
+      <trkpt lat="

--- a/test/fixtures/gpx/fail-no-features.gpx
+++ b/test/fixtures/gpx/fail-no-features.gpx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+  <trk>
+    <trkseg>
+    </trkseg>
+  </trk>
+</gpx>

--- a/test/fixtures/gpx/ok-valid-file.gpx
+++ b/test/fixtures/gpx/ok-valid-file.gpx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.0" creator="http://www.topografix.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/0" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+  <trk>
+    <trkseg>
+      <trkpt lat="34.02357666666666" lon="-118.480265"/>
+      <trkpt lat="34.023558333333334" lon="-118.480315"/>
+      <trkpt lat="34.023556666666664" lon="-118.48032"/>
+      <trkpt lat="34.023556666666664" lon="-118.48032"/>
+    </trkseg>
+  </trk>
+</gpx>

--- a/test/fixtures/kml/fail-duplicate-layer-names.kml
+++ b/test/fixtures/kml/fail-duplicate-layer-names.kml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Folder>
+	<name>duplicate layer names</name>
+	<open>1</open>
+	<Folder>
+		<name>duplicate layer name</name>
+	</Folder>
+	<Folder>
+		<name>duplicate layer name</name>
+	</Folder>
+	<Folder>
+		<name>layer 2</name>
+	</Folder>
+	<Folder>
+		<name>layer 2</name>
+	</Folder>
+</Folder>
+</kml>

--- a/test/fixtures/kml/fail-empty-features-only.kml
+++ b/test/fixtures/kml/fail-empty-features-only.kml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>empty-features-only.kml</name>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<StyleMap id="m_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Folder>
+		<name>empty-features-only</name>
+		<open>1</open>
+		<Placemark>
+			<name>empty polygon</name>
+			<styleUrl>#m_ylw-pushpin</styleUrl>
+			<Polygon>
+				<tessellate>1</tessellate>
+				<outerBoundaryIs>
+					<LinearRing>
+						<coordinates>
+						</coordinates>
+					</LinearRing>
+				</outerBoundaryIs>
+			</Polygon>
+		</Placemark>
+		<Placemark>
+			<name>empty line</name>
+			<styleUrl>#m_ylw-pushpin0</styleUrl>
+			<LineString>
+				<tessellate>1</tessellate>
+				<coordinates>
+				</coordinates>
+			</LineString>
+		</Placemark>
+	</Folder>
+</Document>
+</kml>

--- a/test/fixtures/kml/fail-invalid.kml
+++ b/test/fixtures/kml/fail-invalid.kml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Folder>
+	<name>invalid</name>
+	<open>1</open>
+	<Folder>

--- a/test/fixtures/kml/fail-more-than-15-layers.kml
+++ b/test/fixtures/kml/fail-more-than-15-layers.kml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Folder>
+	<name>more than 15 layers</name>
+	<open>1</open>
+	<Folder>
+		<name>layer 1</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 2</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 3</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 4</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 5</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 6</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 7</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 8</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 9</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 10</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 11</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 12</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 13</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 14</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 15</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 16</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 17</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 18</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 19</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 20</name>
+		<open>1</open>
+	</Folder>
+	<Folder>
+		<name>layer 21</name>
+	</Folder>
+</Folder>
+</kml>

--- a/test/fixtures/kml/ok-layers-folders-emptygeometries.kml
+++ b/test/fixtures/kml/ok-layers-folders-emptygeometries.kml
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>my-test.kml</name>
+	<open>1</open>
+	<Style id="s_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ffff0000</color>
+			<width>10</width>
+		</LineStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ffff0000</color>
+			<width>10</width>
+		</LineStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<StyleMap id="msn_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin1</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="sh_ylw-pushpin">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0000ff</color>
+			<width>8</width>
+		</LineStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff000000</color>
+			<width>10</width>
+		</LineStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff005500</color>
+			<width>1.9</width>
+		</LineStyle>
+		<PolyStyle>
+			<color>7f00aa00</color>
+		</PolyStyle>
+	</Style>
+	<Style id="sn_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff000000</color>
+			<width>10</width>
+		</LineStyle>
+	</Style>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin1</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="m_ylw-pushpin1">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin0</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl1</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="m_ylw-pushpin0">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<StyleMap id="msn_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin1</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin0</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="sn_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff0000ff</color>
+			<width>8</width>
+		</LineStyle>
+	</Style>
+	<Style id="s_ylw-pushpin_hl1">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin0">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<StyleMap id="msn_ylw-pushpin1">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="sh_ylw-pushpin1">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+		<LineStyle>
+			<color>ff005500</color>
+			<width>1.9</width>
+		</LineStyle>
+		<PolyStyle>
+			<color>7f00aa00</color>
+		</PolyStyle>
+	</Style>
+	<Placemark>
+		<name>point-01</name>
+		<description>desc point-01</description>
+		<Camera>
+			<longitude>16.40966023583767</longitude>
+			<latitude>48.1925069364187</latitude>
+			<altitude>10368.63837475184</altitude>
+			<heading>9.350800161469291</heading>
+			<tilt>24.50671614749143</tilt>
+			<roll>-1.234536521210208</roll>
+			<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+		</Camera>
+		<styleUrl>#m_ylw-pushpin0</styleUrl>
+		<Point>
+			<gx:drawOrder>1</gx:drawOrder>
+			<coordinates>16.41350218768393,48.23785515709087,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>line-01</name>
+		<description><![CDATA[desc line-01 <a href="https://www.mapbox.com">https://www.mapbox.com</a>]]></description>
+		<styleUrl>#m_ylw-pushpin</styleUrl>
+		<LineString>
+			<tessellate>1</tessellate>
+			<coordinates>
+				16.43667340118919,48.2137480651988,0 16.43405477350426,48.22364142638448,0 16.43490893897016,48.23095505929151,0 16.4302280634805,48.23577097007643,0 16.42370258660831,48.24160187549051,0 16.41306849787137,48.24664180670233,0 16.4020238900489,48.24966207010675,0 16.39124480989305,48.24998720617013,0 
+			</coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<name>polygon-01</name>
+		<description>poly 01 desc</description>
+		<styleUrl>#m_ylw-pushpin1</styleUrl>
+		<Polygon>
+			<tessellate>1</tessellate>
+			<outerBoundaryIs>
+				<LinearRing>
+					<coordinates>
+						16.39880116789466,48.24185818661861,0 16.40685069000169,48.23402265838939,0 16.42861766173791,48.21955165225462,0 16.42570050409206,48.23076672152668,0 16.42623122485864,48.23663446297304,0 16.42065446360477,48.24101476128649,0 16.41009581088264,48.2463984284906,0 16.39528063678205,48.24815169056571,0 16.39880116789466,48.24185818661861,0 
+					</coordinates>
+				</LinearRing>
+			</outerBoundaryIs>
+		</Polygon>
+	</Placemark>
+	<Folder>
+		<name>folder-02</name>
+		<open>1</open>
+		<description>desc folder-02</description>
+		<gx:balloonVisibility>1</gx:balloonVisibility>
+		<Placemark>
+			<name>polygon-03-empty</name>
+			<description>desc polygon-03-empty</description>
+			<styleUrl>#msn_ylw-pushpin0</styleUrl>
+			<Polygon>
+				<tessellate>1</tessellate>
+				<outerBoundaryIs>
+					<LinearRing>
+						<coordinates>
+						</coordinates>
+					</LinearRing>
+				</outerBoundaryIs>
+			</Polygon>
+		</Placemark>
+		<Placemark>
+			<name>line04-empty</name>
+			<description>desc line04-empty</description>
+			<styleUrl>#msn_ylw-pushpin1</styleUrl>
+			<LineString>
+				<tessellate>1</tessellate>
+				<coordinates>
+				</coordinates>
+			</LineString>
+		</Placemark>
+		<Placemark>
+			<name>point-03-empty</name>
+			<description>desc point-03-empty</description>
+			<Camera>
+				<longitude>16.40966023583767</longitude>
+				<latitude>48.1925069364187</latitude>
+				<altitude>10368.63837475184</altitude>
+				<heading>9.350800161469291</heading>
+				<tilt>24.50671614749143</tilt>
+				<roll>-1.234536521210208</roll>
+				<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+			</Camera>
+			<styleUrl>#m_ylw-pushpin0</styleUrl>
+			<Point>
+				<gx:drawOrder>1</gx:drawOrder>
+				<coordinates>16.42002042755009,48.23441390791601,0</coordinates>
+			</Point>
+		</Placemark>
+	</Folder>
+	<Folder>
+		<name>folder-01</name>
+		<open>1</open>
+		<description>desc folder-01</description>
+		<Placemark>
+			<name>polygon-02</name>
+			<description>desc polygon-02</description>
+			<styleUrl>#msn_ylw-pushpin0</styleUrl>
+			<Polygon>
+				<tessellate>1</tessellate>
+				<outerBoundaryIs>
+					<LinearRing>
+						<coordinates>
+							16.37117328551933,48.2580459823847,0 16.37265821578014,48.24973712333478,0 16.36217236784517,48.23463724442687,0 16.36784902284754,48.22609016751182,0 16.36942113029388,48.22027233512995,0 16.37688332475139,48.21360006593482,0 16.38339377402438,48.21197484254892,0 16.39003747137017,48.21391783901046,0 16.39405868247631,48.21304620343092,0 16.39782482806304,48.20766795435579,0 16.39844282391005,48.20358062827769,0 16.40723315758465,48.20112830060737,0 16.41594063835881,48.19413854002189,0 16.43337009687389,48.20504934949183,0 16.37117328551933,48.2580459823847,0 
+						</coordinates>
+					</LinearRing>
+				</outerBoundaryIs>
+			</Polygon>
+		</Placemark>
+		<Placemark>
+			<name>line-02</name>
+			<description>desc line-02</description>
+			<styleUrl>#msn_ylw-pushpin</styleUrl>
+			<LineString>
+				<tessellate>1</tessellate>
+				<coordinates>
+					16.37894775762214,48.21134702941436,0 16.43387685193025,48.24114369357682,0 
+				</coordinates>
+			</LineString>
+		</Placemark>
+		<Placemark>
+			<name>point-02-label</name>
+			<Camera>
+				<longitude>16.40966023583767</longitude>
+				<latitude>48.1925069364187</latitude>
+				<altitude>10368.63837475184</altitude>
+				<heading>9.350800161469291</heading>
+				<tilt>24.50671614749143</tilt>
+				<roll>-1.234536521210208</roll>
+				<gx:altitudeMode>relativeToSeaFloor</gx:altitudeMode>
+			</Camera>
+			<styleUrl>#m_ylw-pushpin0</styleUrl>
+			<Point>
+				<gx:drawOrder>1</gx:drawOrder>
+				<coordinates>16.38705972732914,48.22482302405027,0</coordinates>
+			</Point>
+		</Placemark>
+		<Folder>
+			<name>folder-01-01</name>
+			<description>desc folder-01-01: subfolder of folder-01</description>
+			<Placemark>
+				<name>line-03</name>
+				<description>desc line-03</description>
+				<styleUrl>#msn_ylw-pushpin1</styleUrl>
+				<LineString>
+					<tessellate>1</tessellate>
+					<coordinates>
+						16.44335342786484,48.20114149643969,0 16.40568329778731,48.23086456817817,0 16.36679489808114,48.27148805960164,0 
+					</coordinates>
+				</LineString>
+			</Placemark>
+		</Folder>
+	</Folder>
+</Document>
+</kml>

--- a/test/fixtures/kml/ok-special-character-layer.kml
+++ b/test/fixtures/kml/ok-special-character-layer.kml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<name>special-character-layer.kml</name>
+	<open>1</open>
+	<Style id="s_ylw-pushpin_hl">
+		<IconStyle>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<StyleMap id="m_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#s_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#s_ylw-pushpin_hl</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="s_ylw-pushpin">
+		<IconStyle>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Folder>
+		<name>special (characters; in &amp; this layer)</name>
+		<open>1</open>
+		<Placemark>
+			<name>austria</name>
+			<styleUrl>#m_ylw-pushpin</styleUrl>
+			<Polygon>
+				<tessellate>1</tessellate>
+				<outerBoundaryIs>
+					<LinearRing>
+						<coordinates>
+							9.948510701496256,47.59254872603884,0 9.672308521268427,47.51887202620658,0 9.611972620508587,47.10144711856087,0 10.11419595290811,46.88714749310341,0 11.09025185164879,46.82641134193905,0 11.2376024800754,46.97309929750735,0 12.13119294670139,46.97849267002405,0 12.51525275763799,46.63142694751628,0 14.50865044058264,46.37350618755779,0 14.99391010229719,46.62667660271019,0 16.02143725382271,46.64721174317448,0 15.96370578945158,46.82053731322057,0 16.4874285966801,46.9927325908894,0 16.37902770093174,47.37192585223085,0 16.65294287220463,47.39888541041359,0 16.73148946028918,47.61863474528875,0 17.07966630883628,47.69436361828313,0 17.24417441158853,48.01782751821557,0 16.83586264286678,48.43898064750138,0 17.0557805956535,48.67694767611934,0 15.03343213066511,48.95727325862828,0 14.7368523875758,48.6029992202009,0 13.91386920367444,48.75468430317257,0 12.79851598707308,48.1284798056311,0 13.04876099811421,47.52574933991964,0 9.916972408310627,47.44292919604388,0 9.948510701496256,47.59254872603884,0 
+						</coordinates>
+					</LinearRing>
+				</outerBoundaryIs>
+			</Polygon>
+		</Placemark>
+	</Folder>
+</Document>
+</kml>

--- a/test/fixtures/mbtiles-count/make-mbtiles.js
+++ b/test/fixtures/mbtiles-count/make-mbtiles.js
@@ -31,7 +31,14 @@ module.exports = function(filepath, numTiles, callback) {
 
         q.awaitAll(function(err) {
           if (err) return callback(err);
-          mbtiles.stopWriting(callback);
+          mbtiles.stopWriting(function(err) {
+            if (err) return callback(err);
+            mbtiles.close(function(err) {
+              if (err) return callback(err);
+              mbtiles = null;
+              callback();
+            });
+          });
         });
       });
     });

--- a/test/geojson-bom.test.js
+++ b/test/geojson-bom.test.js
@@ -42,7 +42,8 @@ test('[geojson-bom] removes bom', function(assert) {
     assert.doesNotThrow(function() {
       JSON.parse(outData);
     }, 'outfile is JSON.parse-able');
-
-    assert.end();
+    fs.unlink(outfile, function(err) {
+      assert.end(err);
+    });
   });
 });

--- a/test/geojson-bom.test.js
+++ b/test/geojson-bom.test.js
@@ -42,6 +42,7 @@ test('[geojson-bom] removes bom', function(assert) {
     assert.doesNotThrow(function() {
       JSON.parse(outData);
     }, 'outfile is JSON.parse-able');
+
     fs.unlink(outfile, function(err) {
       assert.end(err);
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,10 +21,9 @@ test('[index] preprocesses', function(assert) {
       assert.ok(fs.statSync(outfile), 'outfile exists');
       assert.ok(!isNaN(parts), 'reported a number of parts');
       assert.ok(Array.isArray(descriptions), 'returns array of descriptions');
-      fs.unlink(tmpfile, function(err) {
-        if (err) throw err;
-        assert.end();
-      });
+      fs.unlinkSync(outfile);
+      fs.unlinkSync(tmpfile);
+      assert.end();
     });
   }
 });

--- a/test/preprocessors.test.js
+++ b/test/preprocessors.test.js
@@ -78,6 +78,7 @@ test('[preprocessorcery] preprocessorize', function(assert) {
       var outdir = path.dirname(outfile);
       assert.equal(outdir, indir, 'places output files in same directory as input');
       fs.unlinkSync(tmpfile);
+      fs.unlinkSync(outfile);
       assert.end();
     });
   }

--- a/test/shp-index.test.js
+++ b/test/shp-index.test.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var crypto = require('crypto');
 var index = require('../preprocessors/shp-index.preprocessor');
 var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
 
 function tmpfile(callback) {
   var dir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
@@ -46,7 +47,9 @@ test('[shp-index] indexes (input folder output file)', function(assert) {
       fs.stat(outfile, function(err, stats) {
         assert.equal(files.length, 1, 'created index file');
         assert.equal(stats.size, 428328, 'index created using index-parts');
-        assert.end();
+        rimraf(path.dirname(outfile), function(err) {
+          assert.end(err);
+        });
       });
     });
   });
@@ -65,7 +68,9 @@ test('[shp-index] indexes (input folder output folder)', function(assert) {
       fs.stat(outfile, function(err, stats) {
         assert.equal(files.length, 1, 'created index file');
         assert.equal(stats.size, 428328, 'index created using index-parts');
-        assert.end();
+        rimraf(path.dirname(outfile), function(err) {
+          assert.end(err);
+        });
       });
     });
   });
@@ -84,7 +89,9 @@ test('[shp-index] indexes (input file output file)', function(assert) {
       fs.stat(outfile, function(err, stats) {
         assert.equal(files.length, 1, 'created index file');
         assert.equal(stats.size, 428328, 'index created using index-parts');
-        assert.end();
+        rimraf(path.dirname(outfile), function(err) {
+          assert.end(err);
+        });
       });
     });
   });
@@ -103,7 +110,9 @@ test('[shp-index] indexes (input file output folder)', function(assert) {
       fs.stat(outfile, function(err, stats) {
         assert.equal(files.length, 1, 'created index file');
         assert.equal(stats.size, 428328, 'index created using index-parts');
-        assert.end();
+        rimraf(path.dirname(outfile), function(err) {
+          assert.end(err);
+        });
       });
     });
   });
@@ -120,7 +129,9 @@ test('[shp-index] does not index (input folder output file - no index)', functio
         });
 
       assert.equal(files.length, 0, 'did not create index file');
-      assert.end();
+      rimraf(path.dirname(outfile), function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -136,7 +147,9 @@ test('[shp-index] does not index (input file output file - no index)', function(
         });
 
       assert.equal(files.length, 0, 'did not create index file');
-      assert.end();
+      rimraf(path.dirname(outfile), function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -152,7 +165,9 @@ test('[shp-index] does not index (input file output folder - no index)', functio
         });
 
       assert.equal(files.length, 0, 'did not create index file');
-      assert.end();
+      rimraf(path.dirname(outfile), function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -168,7 +183,9 @@ test('[shp-index] does not contain pre-existing index (input file output folder 
         });
 
       assert.equal(files.length, 0, 'does not contain pre-existing index');
-      assert.end();
+      rimraf(path.dirname(outfile), function(err) {
+        assert.end(err);
+      });
     });
   });
 });

--- a/test/spatial-index.test.js
+++ b/test/spatial-index.test.js
@@ -61,8 +61,6 @@ test('[spatial-index] indexes (input folder output file)', function(assert) {
         assert.equal(original, sum);
         assert.ifError(err, 'no error');
         assert.ok(fs.existsSync(path.join(outdir, 'valid.geojson.index')));
-        fs.unlinkSync(path.join(outdir, 'valid.geojson'));
-        fs.unlinkSync(path.join(outdir, 'valid.geojson.index'));
         assert.end();
       });
     });

--- a/test/spatial-index.test.js
+++ b/test/spatial-index.test.js
@@ -61,6 +61,8 @@ test('[spatial-index] indexes (input folder output file)', function(assert) {
         assert.equal(original, sum);
         assert.ifError(err, 'no error');
         assert.ok(fs.existsSync(path.join(outdir, 'valid.geojson.index')));
+        fs.unlinkSync(path.join(outdir, 'valid.geojson'));
+        fs.unlinkSync(path.join(outdir, 'valid.geojson.index'));
         assert.end();
       });
     });

--- a/test/spatial-index.test.js
+++ b/test/spatial-index.test.js
@@ -6,6 +6,7 @@ var crypto = require('crypto');
 var index = require('../preprocessors/spatial-index.preprocessor');
 var mkdirp = require('mkdirp');
 var checksum = require('checksum');
+var rimraf = require('rimraf');
 
 function tmpdir(callback) {
   var dir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
@@ -26,7 +27,7 @@ test('[spatial-index] criteria: not an indexable file', function(assert) {
 });
 
 test('[spatial-index] exposes index_worthy_size', function(assert) {
-  assert.equal(index.index_worthy_size, 10485760);
+  assert.equal(index.index_worthy_size, 10 * 1024 * 1024); //10MB
   assert.end();
 });
 
@@ -61,7 +62,10 @@ test('[spatial-index] indexes (input folder output file)', function(assert) {
         assert.equal(original, sum);
         assert.ifError(err, 'no error');
         assert.ok(fs.existsSync(path.join(outdir, 'valid.geojson.index')));
-        assert.end();
+        rimraf(outdir, function(err) {
+          if (err) throw err;
+          assert.end();
+        });
       });
     });
   });
@@ -81,7 +85,10 @@ test('[spatial-index] handles error in case of invalid feature', function(assert
       checksum.file(path.join(outdir, 'index-validate-flag.geojson'), function(error, sum) {
         assert.equal(original, sum);
         assert.notOk(fs.existsSync(path.join(outdir, 'index-validate-flag.geojson.index')), 'index file should not exist due to feature error');
-        assert.end();
+        rimraf(outdir, function(err) {
+          if (err) throw err;
+          assert.end();
+        });
       });
     });
   });

--- a/test/tif-reproject.test.js
+++ b/test/tif-reproject.test.js
@@ -1,6 +1,7 @@
 var test = require('tape');
 var reproject = require('../preprocessors/tif-reproject.preprocessor');
 var os = require('os');
+var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var googleMerc = path.resolve(__dirname, 'fixtures', 'google-merc.tif');
@@ -56,6 +57,9 @@ test('[tif-reproject] reprojection: to epsg:3857', function(assert) {
     assert.ifError(err, 'no error');
     var ds = gdal.open(outfile);
     assert.ok(ds.srs.isSame(gdal.SpatialReference.fromEPSG(3857)), 'reprojected correctly');
+    ds.close();
+    ds = null;
+    fs.unlinkSync(outfile);
     assert.end();
   });
 });

--- a/test/tif-toBytes.test.js
+++ b/test/tif-toBytes.test.js
@@ -49,6 +49,7 @@ test('[tif-toBytes] convert to bytes', function(assert) {
     ds.bands.forEach(function(band) {
       assert.equal(band.dataType, gdal.GDT_Byte, 'converted band ' + band.id + ' to bytes');
     });
+
     ds.close();
     ds = null;
     console.error('TODO: unlink is stil failing, look into "toBytes"');

--- a/test/tif-toBytes.test.js
+++ b/test/tif-toBytes.test.js
@@ -52,10 +52,8 @@ test('[tif-toBytes] convert to bytes', function(assert) {
 
     ds.close();
     ds = null;
-    console.error('TODO: unlink is stil failing, look into "toBytes"');
     fs.unlink(outfile, function(err) {
       assert.end(err);
     });
-
   });
 });

--- a/test/tif-toBytes.test.js
+++ b/test/tif-toBytes.test.js
@@ -1,6 +1,7 @@
 var test = require('tape');
 var toBytes = require('../preprocessors/tif-toBytes.preprocessor');
 var os = require('os');
+var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var geojson = path.resolve(__dirname, 'fixtures', 'valid.geojson');
@@ -48,7 +49,12 @@ test('[tif-toBytes] convert to bytes', function(assert) {
     ds.bands.forEach(function(band) {
       assert.equal(band.dataType, gdal.GDT_Byte, 'converted band ' + band.id + ' to bytes');
     });
+    ds.close();
+    ds = null;
+    console.error('TODO: unlink is stil failing, look into "toBytes"');
+    fs.unlink(outfile, function(err) {
+      assert.end(err);
+    });
 
-    assert.end();
   });
 });

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -24,7 +24,6 @@ var cmd = [copy_cmd, fixtureDir, tmpdir].join(' ');
 exec(cmd, function(err) {
   if (err) throw err;
 
-  console.log(tmpdir);
   var q = queue();
   var fixtures = fs.readdirSync(tmpdir);
   fixtures.forEach(function(fixture) {
@@ -34,9 +33,10 @@ exec(cmd, function(err) {
         var outdirectory = path.join(tmpdir, crypto.randomBytes(8).toString('hex'));
         togeojson(gpx, outdirectory, function(err) {
           if (fixture.indexOf('ok') === 0) {
-            assert.equal(err, undefined, ': GPX was processed');
             var converted = fs.readdirSync(outdirectory);
+            assert.equal(err, undefined, ': GPX was processed');
             assert.notEqual(converted.length, 0, ': verify output files were created');
+            assert.ok(fs.existsSync(path.join(outdirectory, 'metadata.json')), ': contains metadata for original gpx');
           } else {
             assert.equal(typeof err, typeof new Error(), ': detected invalid GPX, ' + err);
           }

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -58,12 +58,14 @@ test('[GPX togeojson] fails empty features only', function(assert) {
 
 test('[GPX togeojson] convert and index valid GPX', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'gpx', 'ok-valid-file.gpx');
+  togeojson.index_worthy_size = 100; // 100 bytes
 
   tmpdir(function(err, outdir) {
     togeojson(infile, outdir, function(err) {
       if (err) throw err;
       assert.ifError(err, 'no error');
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson')), 'converted layer');
+      assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original gpx');
       assert.end();
     });

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -1,0 +1,57 @@
+var test = require('tape');
+var path = require('path');
+var os = require('os');
+var fs = require('fs');
+var crypto = require('crypto');
+var exec = require('child_process').exec;
+var queue = require('queue-async');
+var rimraf = require('rimraf');
+var togeojson = require('../preprocessors/togeojson-gpx.preprocessor');
+
+// Perform all preprocessorcery in a temporary directory. Otherwise output files
+// with random names will litter the fixture directory
+var fixtureDir = path.resolve(__dirname, 'fixtures', 'gpx');
+var tmpdir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+var copy_cmd = 'cp -r';
+if (process.platform === 'win32') {
+  //during tests %PATH% env var is completely stripped. add Windows system dir back to get xcopy
+  process.env.Path += ';' + path.join(process.env.windir, 'system32');
+  copy_cmd = 'xcopy /s /y';
+  tmpdir += '\\';
+}
+
+var cmd = [copy_cmd, fixtureDir, tmpdir].join(' ');
+exec(cmd, function(err) {
+  if (err) throw err;
+
+  console.log(tmpdir);
+  var q = queue();
+  var fixtures = fs.readdirSync(tmpdir);
+  fixtures.forEach(function(fixture) {
+    q.defer(function(next) {
+      test('[GPX ' + fixture + ']', function(assert) {
+        var gpx = path.join(tmpdir, fixture);
+        var outdirectory = path.join(tmpdir, crypto.randomBytes(8).toString('hex'));
+        togeojson(gpx, outdirectory, function(err) {
+          if (fixture.indexOf('ok') === 0) {
+            assert.equal(err, undefined, ': GPX was processed');
+            var converted = fs.readdirSync(outdirectory);
+            assert.notEqual(converted.length, 0, ': verify output files were created');
+          } else {
+            assert.equal(typeof err, typeof new Error(), ': detected invalid GPX, ' + err);
+          }
+
+          assert.end();
+          next();
+        });
+      });
+    });
+  });
+
+  //clean up tmp directory
+  q.awaitAll(function(err) {
+    if (err) throw err;
+    rimraf.sync(tmpdir);
+  });
+});
+

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -4,6 +4,7 @@ var os = require('os');
 var fs = require('fs');
 var crypto = require('crypto');
 var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
 var exec = require('child_process').exec;
 var togeojson = require('../preprocessors/togeojson-gpx.preprocessor');
 
@@ -39,7 +40,9 @@ test('[GPX togeojson] fails duplicate layer names', function(assert) {
     togeojson(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
       assert.equal(err.message, 'GPX does not contain any valid features.', 'expected error message');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -51,7 +54,9 @@ test('[GPX togeojson] fails empty features only', function(assert) {
     togeojson(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
       assert.equal(err.message, 'Error: Error opening dataset', 'expected error message');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -67,7 +72,9 @@ test('[GPX togeojson] convert and index valid GPX', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original gpx');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -83,14 +83,19 @@ test('[KML togeojson] fails empty features only', function(assert) {
 
 test('[KML togeojson] convert and index valid kml', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-layers-folders-emptygeometries.kml');
+  togeojson.index_worthy_size = 100; // 100 bytes
 
   tmpdir(function(err, outdir) {
     togeojson(infile, outdir, function(err) {
       assert.ifError(err, 'no error');
       assert.ok(fs.existsSync(path.join(outdir, 'folder-01-01.geojson')), 'converted layer');
+      assert.ok(fs.existsSync(path.join(outdir, 'folder-01-01.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'folder-01.geojson')), 'converted layer');
+      assert.ok(fs.existsSync(path.join(outdir, 'folder-01.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'folder-02.geojson')), 'converted layer');
+      assert.ok(fs.existsSync(path.join(outdir, 'folder-02.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson')), 'converted layer');
+      assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
       assert.end();
     });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -1,0 +1,57 @@
+var test = require('tape');
+var path = require('path');
+var os = require('os');
+var fs = require('fs');
+var crypto = require('crypto');
+var exec = require('child_process').exec;
+var queue = require('queue-async');
+var rimraf = require('rimraf');
+var togeojson = require('../preprocessors/togeojson-kml.preprocessor');
+
+// Perform all preprocessorcery in a temporary directory. Otherwise output files
+// with random names will litter the fixture directory
+var fixtureDir = path.resolve(__dirname, 'fixtures', 'kml');
+var tmpdir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+var copy_cmd = 'cp -r';
+if (process.platform === 'win32') {
+  //during tests %PATH% env var is completely stripped. add Windows system dir back to get xcopy
+  process.env.Path += ';' + path.join(process.env.windir, 'system32');
+  copy_cmd = 'xcopy /s /y';
+  tmpdir += '\\';
+}
+
+var cmd = [copy_cmd, fixtureDir, tmpdir].join(' ');
+exec(cmd, function(err) {
+  if (err) throw err;
+
+  console.log(tmpdir);
+  var q = queue();
+  var fixtures = fs.readdirSync(tmpdir);
+  fixtures.forEach(function(fixture) {
+    q.defer(function(next) {
+      test('[KML ' + fixture + ']', function(assert) {
+        var kml = path.join(tmpdir, fixture);
+        var outdirectory = path.join(tmpdir, crypto.randomBytes(8).toString('hex'));
+        togeojson(kml, outdirectory, function(err) {
+          if (fixture.indexOf('ok') === 0) {
+            assert.equal(err, undefined, ': KML was procssed');
+            var converted = fs.readdirSync(outdirectory);
+            assert.notEqual(converted.length, 0, ': verify output files were created');
+          } else {
+            assert.equal(typeof err, typeof new Error(), ': detected invalid KML, ' + err);
+          }
+
+          assert.end();
+          next();
+        });
+      });
+    });
+  });
+
+  //clean up tmp directory
+  q.awaitAll(function(err) {
+    if (err) throw err;
+    rimraf.sync(tmpdir);
+  });
+});
+

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -34,9 +34,11 @@ exec(cmd, function(err) {
         var outdirectory = path.join(tmpdir, crypto.randomBytes(8).toString('hex'));
         togeojson(kml, outdirectory, function(err) {
           if (fixture.indexOf('ok') === 0) {
-            assert.equal(err, undefined, ': KML was procssed');
             var converted = fs.readdirSync(outdirectory);
+            console.log(converted);
+            assert.equal(err, undefined, ': KML was procssed');
             assert.notEqual(converted.length, 0, ': verify output files were created');
+            //assert.ok(fs.existsSync(path.join(outdirectory, 'metadata.json')), ': contains metadata for original kml');
           } else {
             assert.equal(typeof err, typeof new Error(), ': detected invalid KML, ' + err);
           }

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -7,53 +7,163 @@ var exec = require('child_process').exec;
 var queue = require('queue-async');
 var rimraf = require('rimraf');
 var togeojson = require('../preprocessors/togeojson-kml.preprocessor');
+var checksum = require('checksum');
 
 // Perform all preprocessorcery in a temporary directory. Otherwise output files
 // with random names will litter the fixture directory
-var fixtureDir = path.resolve(__dirname, 'fixtures', 'kml');
-var tmpdir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
-var copy_cmd = 'cp -r';
-if (process.platform === 'win32') {
-  //during tests %PATH% env var is completely stripped. add Windows system dir back to get xcopy
-  process.env.Path += ';' + path.join(process.env.windir, 'system32');
-  copy_cmd = 'xcopy /s /y';
-  tmpdir += '\\';
+function tmpdir(callback) {
+  var dir = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
+  var fixtureDir = path.resolve(__dirname, 'fixtures', 'kml');
+  var copy_cmd = 'cp -r';
+  
+  if (process.platform === 'win32') {
+    //during tests %PATH% env var is completely stripped. add Windows system dir back to get xcopy
+    process.env.Path += ';' + path.join(process.env.windir, 'system32');
+    copy_cmd = 'xcopy /s /y';
+    dir += '\\';
+  }
+
+  var cmd = [copy_cmd, fixtureDir, dir].join(' ');
+  exec(cmd, function(err) {
+    if (err) return callback(err);
+    callback(null, dir);
+  });
 }
 
-var cmd = [copy_cmd, fixtureDir, tmpdir].join(' ');
-exec(cmd, function(err) {
-  if (err) throw err;
+test('[KML togeojson] fails duplicate layer names', function(assert) {
+  var infile = path.resolve(__dirname, 'fixtures', 'kml','fail-duplicate-layer-names.kml');
+  var original;
+  checksum.file(infile, function(error, sum) {
+    original = sum;
+  });
 
-  console.log(tmpdir);
-  var q = queue();
-  var fixtures = fs.readdirSync(tmpdir);
-  fixtures.forEach(function(fixture) {
-    q.defer(function(next) {
-      test('[KML ' + fixture + ']', function(assert) {
-        var kml = path.join(tmpdir, fixture);
-        var outdirectory = path.join(tmpdir, crypto.randomBytes(8).toString('hex'));
-        togeojson(kml, outdirectory, function(err) {
-          if (fixture.indexOf('ok') === 0) {
-            var converted = fs.readdirSync(outdirectory);
-            console.log(converted);
-            assert.equal(err, undefined, ': KML was procssed');
-            assert.notEqual(converted.length, 0, ': verify output files were created');
-            //assert.ok(fs.existsSync(path.join(outdirectory, 'metadata.json')), ': contains metadata for original kml');
-          } else {
-            assert.equal(typeof err, typeof new Error(), ': detected invalid KML, ' + err);
-          }
-
-          assert.end();
-          next();
-        });
+  tmpdir(function(err, outdir) {
+    togeojson(infile, outdir, function(err) {
+      assert.ok(err, 'error properly handled');
+      assert.equal(err.message, 'Duplicate layer names! \'duplicate layer name\' found 2 times, \'layer 2\' found 2 times', 'expected error message');
+      checksum.file(path.join(outdir, 'fail-duplicate-layer-names.kml'), function(error, sum) {
+        assert.equal(original, sum);
+        assert.end();
       });
     });
   });
+});
 
-  //clean up tmp directory
-  q.awaitAll(function(err) {
-    if (err) throw err;
-    rimraf.sync(tmpdir);
+test('[KML togeojson] fails empty features only', function(assert) {
+  var infile = path.resolve(__dirname, 'fixtures', 'kml','fail-empty-features-only.kml');
+  var original;
+  checksum.file(infile, function(error, sum) {
+    original = sum;
+  });
+
+  tmpdir(function(err, outdir) {
+    togeojson(infile, outdir, function(err) {
+      assert.ok(err, 'error properly handled');
+      assert.equal(err.message, 'KML does not contain any valid features', 'expected error message');
+      checksum.file(path.join(outdir, 'fail-empty-features-only.kml'), function(error, sum) {
+        assert.equal(original, sum);
+        assert.end();
+      });
+    });
   });
 });
+
+test('[KML togeojson] fails empty features only', function(assert) {
+  var infile = path.resolve(__dirname, 'fixtures', 'kml','fail-invalid.kml');
+  var original;
+  checksum.file(infile, function(error, sum) {
+    original = sum;
+  });
+
+  tmpdir(function(err, outdir) {
+    togeojson(infile, outdir, function(err) {
+      assert.ok(err, 'error properly handled');
+      assert.equal(err.message, 'Error opening dataset', 'expected error message');
+      checksum.file(path.join(outdir, 'fail-invalid.kml'), function(error, sum) {
+        assert.equal(original, sum);
+        assert.end();
+      });
+    });
+  });
+});
+
+test('[KML togeojson] fails empty features only', function(assert) {
+  var infile = path.resolve(__dirname, 'fixtures', 'kml','fail-more-than-15-layers.kml');
+  var original;
+  checksum.file(infile, function(error, sum) {
+    original = sum;
+  });
+
+  tmpdir(function(err, outdir) {
+    togeojson(infile, outdir, function(err) {
+      assert.ok(err, 'error properly handled');
+      assert.equal(err.message, '22 layers found. Maximum of 15 layers allowed.', 'expected error message');
+      checksum.file(path.join(outdir, 'fail-more-than-15-layers.kml'), function(error, sum) {
+        assert.equal(original, sum);
+        assert.end();
+      });
+    });
+  });
+});
+
+test('[KML togeojson] convert and index valid kml', function(assert) {
+  var infile = path.resolve(__dirname, 'fixtures', 'kml','ok-layers-folders-emptygeometries.kml');
+  var original;
+  checksum.file(infile, function(error, sum) {
+    original = sum;
+  });
+
+  tmpdir(function(err, outdir) {
+    togeojson(infile, outdir, function(err) {
+      checksum.file(path.join(outdir, 'ok-layers-folders-emptygeometries.kml'), function(error, sum) {
+        assert.ifError(err, 'no error');
+        assert.equal(original, sum);
+        assert.ok(fs.existsSync(path.join(outdir, 'folder-01-01.geojson.index')), 'indexed layer');
+        assert.ok(fs.existsSync(path.join(outdir, 'folder-01.geojson.index')), 'indexed layer');
+        assert.ok(fs.existsSync(path.join(outdir, 'folder-02.geojson.index')), 'indexed layer');
+        assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'indexed layer');
+        assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
+        assert.end();
+      });
+    });
+  });
+});
+// var cmd = [copy_cmd, fixtureDir, tmpdir].join(' ');
+// console.log(cmd);
+// exec(cmd, function(err) {
+//   if (err) throw err;
+
+//   console.log(tmpdir);
+//   var q = queue();
+//   var fixtures = fs.readdirSync(tmpdir);
+//   fixtures.forEach(function(fixture) {
+//     q.defer(function(next) {
+//       test('[KML ' + fixture + ']', function(assert) {
+//         var kml = path.join(tmpdir, fixture);
+//         var outdirectory = path.join(tmpdir, crypto.randomBytes(8).toString('hex'));
+//         togeojson(kml, outdirectory, function(err) {
+//           if (fixture.indexOf('ok') === 0) {
+//             var converted = fs.readdirSync(outdirectory);
+//             console.log(converted);
+//             assert.equal(err, undefined, ': KML was procssed');
+//             assert.notEqual(converted.length, 0, ': verify output files were created');
+
+//             //assert.ok(fs.existsSync(path.join(outdirectory, 'metadata.json')), ': contains metadata for original kml');
+//           } else {
+//             assert.equal(typeof err, typeof new Error(), ': detected invalid KML, ' + err);
+//           }
+
+//           assert.end();
+//           next();
+//         });
+//       });
+//     });
+//   });
+
+//   //clean up tmp directory
+//   q.awaitAll(function(err) {
+//     if (err) throw err;
+//     rimraf.sync(tmpdir);
+//   });
+// });
 

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -101,3 +101,18 @@ test('[KML togeojson] convert and index valid kml', function(assert) {
     });
   });
 });
+
+test('[KML togeojson] handle layers with special characters', function(assert) {
+  var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-special-character-layer.kml');
+  togeojson.index_worthy_size = 100; // 100 bytes
+
+  tmpdir(function(err, outdir) {
+    togeojson(infile, outdir, function(err) {
+      assert.ifError(err, 'no error');
+      assert.ok(fs.existsSync(path.join(outdir, 'special_characters_in___this_layer.geojson')), 'converted layer');
+      assert.ok(fs.existsSync(path.join(outdir, 'special_characters_in___this_layer.geojson.index')), 'created index');
+      assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
+      assert.end();
+    });
+  });
+});

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -4,6 +4,7 @@ var os = require('os');
 var fs = require('fs');
 var crypto = require('crypto');
 var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
 var exec = require('child_process').exec;
 var togeojson = require('../preprocessors/togeojson-kml.preprocessor');
 
@@ -40,7 +41,9 @@ test('[KML togeojson] fails duplicate layer names', function(assert) {
     togeojson(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
       assert.equal(err.message, 'Duplicate layer names! \'duplicate layer name\' found 2 times, \'layer 2\' found 2 times', 'expected error message');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -52,7 +55,9 @@ test('[KML togeojson] fails empty features only', function(assert) {
     togeojson(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
       assert.equal(err.message, 'KML does not contain any valid features', 'expected error message');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -64,7 +69,9 @@ test('[KML togeojson] fails empty features only', function(assert) {
     togeojson(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
       assert.equal(err.message, 'Error: Error opening dataset', 'expected error message');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -76,7 +83,9 @@ test('[KML togeojson] fails empty features only', function(assert) {
     togeojson(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
       assert.equal(err.message, '22 layers found. Maximum of 15 layers allowed.', 'expected error message');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -97,7 +106,9 @@ test('[KML togeojson] convert and index valid kml', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });
@@ -112,7 +123,9 @@ test('[KML togeojson] handle layers with special characters', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'special_characters_in___this_layer.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'special_characters_in___this_layer.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
-      assert.end();
+      rimraf(outdir, function(err) {
+        assert.end(err);
+      });
     });
   });
 });


### PR DESCRIPTION
Per https://github.com/mapbox/preprocessorcerer/issues/19

- [x] Convert each layer of KML/GPX into geojson file (max 15 layers)
- [x] Add index file for each new file/layer > 10MB
- [x] [Validate layer names](https://github.com/mapbox/preprocessorcerer/commit/1155713d6147615843fe68a2d765dd2232fbed03#commitcomment-16163231)
- [x] Include metadata file for original KML/GPX (run through mapnik-omnivore)
- [x] Drop GPX `track_points`. Found that these are automatically inserted by gdal (most of the time). @BergWerkGIS did we decide on if possible to allow `track_points` produced by an actual GPS device?
- [x] Tests (anything we're not testing that we should?)

@BergWerkGIS 