### PR TITLE
mapnik dev branch, #62

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bytetiff": "~0.3.0",
     "gdal": "~0.8.0",
     "mapbox-file-sniff": "~0.4.0",
-    "mapnik": "~3.5.0",
+    "mapnik": "https://mapnik-slugs.s3.amazonaws.com/node-mapnik-4b3b62a40ceb886f0f8fe686a83d17d3de7d19a3.tar.gz",
     "mkdirp": "^0.5.0",
     "mbtiles": "^0.8.0",
     "queue-async": "^1.0.7",


### PR DESCRIPTION
This tests preprocessorcerer against a new mapnik/node-mapnik binary. Branch created so we can test from mapnik-swoop to see if we successfully catch stderr statements.

- [ ] confirm tests pass in mapnik-swoop, the original source of the failures, https://github.com/mapbox/mapnik-swoop/pull/14

cc/ @artemp @GretaCB @BergWerkGIS @springmeyer 