### PR TITLE
Error handling for expected errors

### DIFF
--- a/bin/perform-preprocessorcery.js
+++ b/bin/perform-preprocessorcery.js
@@ -11,10 +11,15 @@ if (!infile) {
   process.exit(1);
 }
 
-preprocessorcerize(path.resolve(infile), function(err, outfile, parts, descriptions) {
+preprocessorcerize(path.resolve(infile), function(err, valid, message, outfile, parts, descriptions) {
   if (err) {
     console.error(err);
     process.exit(1);
+  }
+
+  if (!valid) {
+    console.error(message);
+    process.exit(3);
   }
 
   console.log(JSON.stringify({

--- a/index.js
+++ b/index.js
@@ -11,28 +11,34 @@ function preprocess(infile, callback) {
 
   fs.stat(infile, getType);
 
+  function fail(err) {
+    err = err || new Error('Any unspecified error was encountered');
+    if (err && err.code === 'EINVALID') return callback(null, false, err.message);
+    return callback(err);
+  }
+
   function getType(err, stats) {
-    if (err) return callback(err);
+    if (err) return fail(err);
     info = stats;
     sniffer.quaff(infile, function(err, type) {
-      if (err) return callback(err);
+      if (err) return fail(err);
       info.filetype = type;
       preprocessors.descriptions(infile, info, performPreprocessorcery);
     });
   }
 
   function performPreprocessorcery(err, result) {
-    if (err) return callback(err);
+    if (err) return fail(err);
     descriptions = result;
     preprocessors(infile, info, getParts);
   }
 
   function getParts(err, outfile) {
-    if (err) return callback(err);
+    if (err) return fail(err);
 
     parts(outfile, info, function(err, parts) {
-      if (err) return callback(err);
-      callback(null, outfile, parts, descriptions);
+      if (err) return fail(err);
+      callback(null, true, null, outfile, parts, descriptions);
     });
   }
 }

--- a/lib/invalid.js
+++ b/lib/invalid.js
@@ -1,0 +1,16 @@
+var os = require('os');
+var path = require('path');
+var util = require('util');
+
+module.exports = function invalid(err) {
+  var msg = typeof err === 'string' ?
+    util.format.apply(this, arguments) : err.message;
+
+  msg = msg
+    .replace(new RegExp(path.join(os.tmpdir(),'[0-9a-z]+-'), 'g'), '');
+
+  var error = new Error(msg);
+  error.code = 'EINVALID';
+  if (err.stack) error.stack = err.stack;
+  return error;
+};

--- a/preprocessors/shp-index.preprocessor.js
+++ b/preprocessors/shp-index.preprocessor.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 var mapnik = require('mapnik');
+var invalid = require('../lib/invalid');
 var shapeindex = path.resolve(mapnik.module_path, 'shapeindex' + (process.platform === 'win32' ? '.exe' : ''));
 if (!fs.existsSync(shapeindex)) {
   throw new Error('shapeindex does not exist at ' + shapeindex);
@@ -26,7 +27,7 @@ module.exports = function(infile, outfile, callback) {
         return path.extname(filename) === '.shp';
       });
 
-      if (!shp.length) return callback(new Error('Could not locate shapefile'));
+      if (!shp.length) return callback(invalid('Could not locate shapefile'));
       inName = path.basename(shp[0], '.shp');
     }
 

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -6,6 +6,7 @@ var spawn = require('child_process').spawn;
 var path = require('path');
 var digest = require('mapnik-omnivore').digest;
 var mapnik = require('mapnik');
+var invalid = require('../lib/invalid');
 var mapnik_index = path.resolve(mapnik.module_path, 'mapnik-index' + (process.platform === 'win32' ? '.exe' : ''));
 if (!fs.existsSync(mapnik_index)) {
   throw new Error('mapnik-index does not exist at ' + mapnik_index);
@@ -88,7 +89,7 @@ module.exports = function(infile, outdirectory, callback) {
 
     ds_gpx.close();
     if (full_feature_cnt === 0) {
-      return callback(new Error('GPX does not contain any valid features.'));
+      return callback(invalid('GPX does not contain any valid features.'));
     }
 
     // Create metadata file for original gpx source

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -183,7 +183,7 @@ function layername_count(ds) {
     }
   }
 
-  return err.length > 0 ? 'Duplicate layer names! ' + err : null;
+  return err.length > 0 ? 'Duplicate layer names: ' + err : null;
 }
 
 //expose this as ENV option?

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -7,6 +7,7 @@ var util = require('util');
 var digest = require('mapnik-omnivore').digest;
 var mapnik = require('mapnik');
 var spawn = require('child_process').spawn;
+var invalid = require('../lib/invalid');
 var mapnik_index = path.resolve(mapnik.module_path, 'mapnik-index' + (process.platform === 'win32' ? '.exe' : ''));
 if (!fs.existsSync(mapnik_index)) {
   throw new Error('mapnik-index does not exist at ' + mapnik_index);
@@ -38,18 +39,18 @@ module.exports = function(infile, outdirectory, callback) {
 
     if (lyr_cnt < 1) {
       ds_kml.close();
-      return callback(new Error('KML does not contain any layers.'));
+      return callback(invalid('KML does not contain any layers.'));
     }
 
     if (lyr_cnt > module.exports.max_layer_count) {
       ds_kml.close();
-      return callback(new Error(util.format('%d layers found. Maximum of %d layers allowed.', lyr_cnt, module.exports.max_layer_count)));
+      return callback(invalid(util.format('%d layers found. Maximum of %d layers allowed.', lyr_cnt, module.exports.max_layer_count)));
     }
 
     var duplicate_lyr_msg = layername_count(ds_kml);
     if (duplicate_lyr_msg) {
       ds_kml.close();
-      return callback(new Error(duplicate_lyr_msg));
+      return callback(invalid(duplicate_lyr_msg));
     }
 
     ds_kml.layers.forEach(function(lyr_kml) {
@@ -98,7 +99,7 @@ module.exports = function(infile, outdirectory, callback) {
 
     ds_kml.close();
     if (full_feature_cnt === 0) {
-      return callback(new Error('KML does not contain any valid features'));
+      return callback(invalid('KML does not contain any valid features'));
     }
 
     // Create metadata file for original gpx source

--- a/test/end2end.test.js
+++ b/test/end2end.test.js
@@ -56,7 +56,7 @@ exec(cmd, function(err) {
   fixtures.forEach(function(fixture) {
     q.defer(function(next) {
       test('[end2end ' + fixture.name + ']', function(assert) {
-        preprocess(fixture.filepath, function(err, outfile, parts, descriptions) {
+        preprocess(fixture.filepath, function(err, valid, message, outfile, parts, descriptions) {
           assert.ifError(err, 'preprocessed');
           assert.deepEqual(descriptions, fixture.descriptions, 'expected preprocessorcery performed');
           outputCheck(outfile, fixture.type, assert, function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,7 @@ test('[index] preprocesses', function(assert) {
     .on('finish', testProcess);
 
   function testProcess() {
-    preprocess(tmpfile, function(err, outfile, parts, descriptions) {
+    preprocess(tmpfile, function(err, valid, message, outfile, parts, descriptions) {
       assert.ifError(err, 'no error');
       assert.ok(fs.statSync(outfile), 'outfile exists');
       assert.ok(!isNaN(parts), 'reported a number of parts');

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -40,7 +40,7 @@ test('[KML togeojson] fails duplicate layer names', function(assert) {
   tmpdir(function(err, outdir) {
     togeojson(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
-      assert.equal(err.message, 'Duplicate layer names! \'duplicate layer name\' found 2 times, \'layer 2\' found 2 times', 'expected error message');
+      assert.equal(err.message, 'Duplicate layer names: \'duplicate layer name\' found 2 times, \'layer 2\' found 2 times', 'expected error message');
       rimraf(outdir, function(err) {
         assert.end(err);
       });


### PR DESCRIPTION
Per bundle-support, preprocessing now triggers expected errors/validation that would be helpful for users to receive. Instead of these errors exiting `1` in unpacker and triggering alarms, makes sense for certain expected errors/invalid uploads to exit `3` and automatically fail.

cc @rclark @mapsam 