### PR TITLE
update error code & message for spatial indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.3
+
+- Properly handle errors from `spatial-index.js` (using `lib/invalid.js`)
+
 ## 0.13.2
 
 - Properly handle expected errors/invalid files (exit 3 instead of exit 1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprocessorcerer",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/preprocessors/spatial-index.preprocessor.js
+++ b/preprocessors/spatial-index.preprocessor.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var spawn = require('child_process').spawn;
 var mapnik = require('mapnik');
 var mapnik_index = path.resolve(mapnik.module_path, 'mapnik-index');
+var invalid = require('../lib/invalid');
 if (!fs.existsSync(mapnik_index)) {
   throw new Error('mapnik-index does not exist at ' + mapnik_index);
 }
@@ -34,7 +35,7 @@ module.exports = function(infile, outdir, callback) {
         .on('exit', function() {
           // If error printed to --validate-features log
           if (data.indexOf('Error') != -1) {
-            callback('Invalid geojson feature');
+            callback(invalid('Invalid CSV or GeoJSON.'));
           }
           else callback();
         });

--- a/test/spatial-index.test.js
+++ b/test/spatial-index.test.js
@@ -81,7 +81,7 @@ test('[spatial-index] handles error in case of invalid feature', function(assert
   tmpdir(function(err, outdir) {
     index(infile, outdir, function(err) {
       assert.ok(err, 'error properly handled');
-      assert.equal(err, 'Invalid geojson feature', 'expected error message');
+      assert.equal(err.message, 'Invalid CSV or GeoJSON.', 'expected error message');
       checksum.file(path.join(outdir, 'index-validate-flag.geojson'), function(error, sum) {
         assert.equal(original, sum);
         assert.notOk(fs.existsSync(path.join(outdir, 'index-validate-flag.geojson.index')), 'index file should not exist due to feature error');


### PR DESCRIPTION
The spatial indexing preprocessor didn't format errors properly, and only returned a string instead of a full error message and code. This uses the `lib/invalid.js` utility to format the error correctly, similarly to the rest of the module.

@GretaCB do you think it's necessary to include an invalid CSV fixture here?