### PR TITLE
upgrade mapnik, gdal, and other deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
- - "0.10"
  - "4"
+ - "6"
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.14.0
+
+- Upgrade node-gdal@0.9.3
+- Upgrade node-mapnik@3.5.14
+- Upgrade mapnik-file-sniff, mapnik-omnivore, node-srs, node-wmtiff, node-wmshp
+
 ## 0.13.4
 
 - mapnik-omnivore@8.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Upgrade node-gdal@0.9.3
 - Upgrade node-mapnik@3.5.14
-- Upgrade mapnik-file-sniff, mapnik-omnivore, node-srs, node-wmtiff, node-wmshp
+- Upgrade mapnik-file-sniff, mapnik-omnivore, node-srs, node-wmtiff, node-wmshp, mbtiles
 
 ## 0.13.4
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/tag-fiesta",
     "mapnik": "~3.5.14",
     "mkdirp": "^0.5.0",
-    "mbtiles": "^0.8.0",
+    "mbtiles": "~0.9.0",
     "queue-async": "^1.0.7",
     "split": "^1.0.0",
     "srs": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,18 +34,18 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "bytetiff": "~0.3.0",
-    "gdal": "~0.8.0",
-    "mapbox-file-sniff": "~0.4.0",
-    "mapnik-omnivore": "~8.0.0",
-    "mapnik": "~3.5.0",
+    "bytetiff": "https://github.com/mapbox/node-bytetiff/tarball/tag-fiesta",
+    "gdal": "~0.9.3",
+    "mapbox-file-sniff": "https://github.com/mapbox/mapbox-file-sniff/tarball/smelloscope",
+    "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/tag-fiesta",
+    "mapnik": "~3.5.14",
     "mkdirp": "^0.5.0",
     "mbtiles": "^0.8.0",
     "queue-async": "^1.0.7",
     "split": "^1.0.0",
-    "srs": "~1.1.0",
-    "wmshp": "~0.3.0",
-    "wmtiff": "~0.3.0"
+    "srs": "~1.2.0",
+    "wmshp": "https://github.com/mapbox/node-wmshp/tarball/tag-fiesta",
+    "wmtiff": "https://github.com/mapbox/node-wmtiff/tarball/tag-fiesta"
   },
   "jshintConfig": {
     "node": true,

--- a/package.json
+++ b/package.json
@@ -34,18 +34,18 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "bytetiff": "https://github.com/mapbox/node-bytetiff/tarball/tag-fiesta",
+    "bytetiff": "~0.4.1",
     "gdal": "~0.9.3",
-    "mapbox-file-sniff": "https://github.com/mapbox/mapbox-file-sniff/tarball/smelloscope",
-    "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/tag-fiesta",
+    "mapbox-file-sniff": "~3.5.2",
+    "mapnik-omnivore": "~8.1.0",
     "mapnik": "~3.5.14",
     "mkdirp": "^0.5.0",
     "mbtiles": "~0.9.0",
     "queue-async": "^1.0.7",
     "split": "^1.0.0",
     "srs": "~1.2.0",
-    "wmshp": "https://github.com/mapbox/node-wmshp/tarball/tag-fiesta",
-    "wmtiff": "https://github.com/mapbox/node-wmtiff/tarball/tag-fiesta"
+    "wmshp": "~0.4.0",
+    "wmtiff": "~0.4.0"
   },
   "jshintConfig": {
     "node": true,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "bytetiff": "~0.4.1",
     "gdal": "~0.9.3",
-    "mapbox-file-sniff": "~3.5.2",
+    "mapbox-file-sniff": "~0.5.2",
     "mapnik-omnivore": "~8.1.0",
     "mapnik": "~3.5.14",
     "mkdirp": "^0.5.0",

--- a/test/end2end.test.js
+++ b/test/end2end.test.js
@@ -102,7 +102,7 @@ function outputCheck(outfile, type, assert, callback) {
     // ends up in epsg:3857
     ds.layers.forEach(function(layer) {
       // https://github.com/mapbox/preprocessorcerer/issues/47
-      assert.ok(!layer.srs.isSame(mercator), layer.name + ' projected to spherical mercator');
+      assert.ok(layer.srs.isSame(mercator), layer.name + ' projected to spherical mercator');
     });
 
     ds.close();


### PR DESCRIPTION
* upgrades mapnik 3.5.14
* upgrades gdal 0.9.3
* upgrades other mapbox deps
* testing on node v4 & v6, no longer 0.10.x

cc @springmeyer @who8mycakes @gretacb