### PR TITLE
Archive original KML/GPX files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.1
+
+- Bundle support: archive original KML/GPX files
+
 ## 0.14.0
 
 - Upgrade node-gdal@0.9.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprocessorcerer",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprocessorcerer",
-  "version": "0.14.1",
+  "version": "0.14.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -96,9 +96,14 @@ module.exports = function(infile, outdirectory, callback) {
     var metadatafile = path.join(outdirectory, '/metadata.json');
     digest(infile, function(err, metadata) {
       fs.writeFile(metadatafile, JSON.stringify(metadata), function(err) {
-        createIndices();
-        if (err) return callback(err);
-        return archiveOriginal(callback);
+        if (err) throw err;
+        createIndices(function(err) {
+          if (err) throw err;
+          archiveOriginal(function(err) {
+            if (err) throw err;
+            return callback(err);
+          });
+        });
       });
     });
 
@@ -120,6 +125,7 @@ module.exports = function(infile, outdirectory, callback) {
 
       q.awaitAll(function(err) {
         if (err) return callback(err);
+        return callback();
       });
     }
 

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -95,21 +95,24 @@ module.exports = function(infile, outdirectory, callback) {
     // Create metadata file for original gpx source
     var metadatafile = path.join(outdirectory, '/metadata.json');
     digest(infile, function(err, metadata) {
-      if (err) return callback(err);
       fs.writeFile(metadatafile, JSON.stringify(metadata), function(err) {
+        createIndices();
         if (err) return callback(err);
-        return createIndices(callback);
+        return archiveOriginal(callback);
       });
     });
 
-    var archivedOriginal = path.join(outdirectory, '/archived.gpx');
-    var infileContents = fs.readFileSync(infile);
+    function archiveOriginal(callback) {
+      var archivedOriginal = path.join(outdirectory, '/archived.gpx');
+      var infileContents = fs.readFileSync(infile);
       fs.writeFile(archivedOriginal, infileContents, function(err) {
         if (err) return callback(err);
+        return callback();
       });
+    }
 
+    // create mapnik index for each geojson layer
     function createIndices(callback) {
-      // create mapnik index for each geojson layer
       var q = queue();
       geojson_files.forEach(function(gj) {
         q.defer(createIndex, gj);
@@ -117,7 +120,6 @@ module.exports = function(infile, outdirectory, callback) {
 
       q.awaitAll(function(err) {
         if (err) return callback(err);
-        return callback();
       });
     }
 

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -102,6 +102,14 @@ module.exports = function(infile, outdirectory, callback) {
       });
     });
 
+    var archivedOriginal = path.join(outdirectory, '/archived.gpx');
+    digest(infile, function(err, callback) {
+      fs.writeFile(archivedOriginal, fs.readFile(infile), function(err) {
+        if (err) return callback(err);
+        return archivedOriginal;
+      });
+    });
+
     function createIndices(callback) {
       // create mapnik index for each geojson layer
       var q = queue();

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -103,12 +103,10 @@ module.exports = function(infile, outdirectory, callback) {
     });
 
     var archivedOriginal = path.join(outdirectory, '/archived.gpx');
-    digest(infile, function(err, callback) {
-      fs.writeFile(archivedOriginal, fs.readFile(infile), function(err) {
+    var infileContents = fs.readFileSync(infile);
+      fs.writeFile(archivedOriginal, infileContents, function(err) {
         if (err) return callback(err);
-        return archivedOriginal;
       });
-    });
 
     function createIndices(callback) {
       // create mapnik index for each geojson layer

--- a/preprocessors/togeojson-gpx.preprocessor.js
+++ b/preprocessors/togeojson-gpx.preprocessor.js
@@ -101,7 +101,7 @@ module.exports = function(infile, outdirectory, callback) {
           if (err) throw err;
           archiveOriginal(function(err) {
             if (err) throw err;
-            return callback(err);
+            return callback();
           });
         });
       });

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -110,10 +110,12 @@ module.exports = function(infile, outdirectory, callback) {
         return createIndices(callback);
       });
     });
-    var originalfile = path.join(outdirectory, '/archived.kml');
-    digest(infile, function(err, archived) {
-      fs.writeFile(originalfile, infile, function(err) {
+
+    var archivedOriginal = path.join(outdirectory, '/archived.kml');
+    digest(infile, function(err, callback) {
+      fs.writeFile(archivedOriginal, fs.readFile(infile), function(err) {
         if (err) return callback(err);
+        return archivedOriginal;
       });
     });
 

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -111,13 +111,13 @@ module.exports = function(infile, outdirectory, callback) {
       });
     });
 
+    // Archive original kml file
     var archivedOriginal = path.join(outdirectory, '/archived.kml');
-    digest(infile, function(err, callback) {
-      fs.writeFile(archivedOriginal, fs.readFile(infile), function(err) {
+    var fileInsides = fs.readFileSync(infile);
+    console.log(fileInsides);
+      fs.writeFile(archivedOriginal, fileInsides, function(err) {
         if (err) return callback(err);
-        return archivedOriginal;
       });
-    });
 
     function createIndices(callback) {
       // create mapnik index for each geojson layer

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -110,6 +110,12 @@ module.exports = function(infile, outdirectory, callback) {
         return createIndices(callback);
       });
     });
+    var originalfile = path.join(outdirectory, '/archived.kml');
+    digest(infile, function(err, archived) {
+      fs.writeFile(originalfile, infile, function(err) {
+        if (err) return callback(err);
+      });
+    });
 
     function createIndices(callback) {
       // create mapnik index for each geojson layer

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -113,9 +113,10 @@ module.exports = function(infile, outdirectory, callback) {
 
     // Archive original kml file
     var archivedOriginal = path.join(outdirectory, '/archived.kml');
-    var fileInsides = fs.readFileSync(infile);
-    console.log(fileInsides);
-      fs.writeFile(archivedOriginal, fileInsides, function(err) {
+    var infileContents = fs.readFileSync(infile);
+    console.log(infileContents);
+
+      fs.writeFile(archivedOriginal, infileContents, function(err) {
         if (err) return callback(err);
       });
 
@@ -197,3 +198,4 @@ function layername_count(ds) {
 //expose this as ENV option?
 module.exports.max_layer_count = 15;
 module.exports.index_worthy_size = 10 * 1024 * 1024; // 10 MB
+module.exports.infileContents;

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -114,11 +114,10 @@ module.exports = function(infile, outdirectory, callback) {
     // Archive original kml file
     var archivedOriginal = path.join(outdirectory, '/archived.kml');
     var infileContents = fs.readFileSync(infile);
-    console.log(infileContents);
 
-      fs.writeFile(archivedOriginal, infileContents, function(err) {
-        if (err) return callback(err);
-      });
+    fs.writeFile(archivedOriginal, infileContents, function(err) {
+      if (err) return callback(err);
+    });
 
     function createIndices(callback) {
       // create mapnik index for each geojson layer
@@ -198,4 +197,3 @@ function layername_count(ds) {
 //expose this as ENV option?
 module.exports.max_layer_count = 15;
 module.exports.index_worthy_size = 10 * 1024 * 1024; // 10 MB
-module.exports.infileContents;

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -111,7 +111,7 @@ module.exports = function(infile, outdirectory, callback) {
           if (err) throw err;
           archiveOriginal(function(err) {
             if (err) throw err;
-            return callback(err);
+            return callback();
           });
         });
       });

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -106,21 +106,25 @@ module.exports = function(infile, outdirectory, callback) {
     var metadatafile = path.join(outdirectory, '/metadata.json');
     digest(infile, function(err, metadata) {
       fs.writeFile(metadatafile, JSON.stringify(metadata), function(err) {
+        createIndices();
         if (err) return callback(err);
-        return createIndices(callback);
+        return archiveOriginal(callback);
       });
     });
 
     // Archive original kml file
-    var archivedOriginal = path.join(outdirectory, '/archived.kml');
-    var infileContents = fs.readFileSync(infile);
+    function archiveOriginal(callback) {
+      var archivedOriginal = path.join(outdirectory, '/archived.kml');
+      var infileContents = fs.readFileSync(infile);
 
-    fs.writeFile(archivedOriginal, infileContents, function(err) {
-      if (err) return callback(err);
-    });
+      fs.writeFile(archivedOriginal, infileContents, function(err) {
+        if (err) return callback(err);
+        return callback();
+      });
+    }
 
+    // create mapnik index for each geojson layer
     function createIndices(callback) {
-      // create mapnik index for each geojson layer
       var q = queue();
       geojson_files.forEach(function(gj) {
         q.defer(createIndex, gj);
@@ -128,7 +132,6 @@ module.exports = function(infile, outdirectory, callback) {
 
       q.awaitAll(function(err) {
         if (err) return callback(err);
-        return callback();
       });
     }
 

--- a/preprocessors/togeojson-kml.preprocessor.js
+++ b/preprocessors/togeojson-kml.preprocessor.js
@@ -102,13 +102,18 @@ module.exports = function(infile, outdirectory, callback) {
       return callback(invalid('KML does not contain any valid features'));
     }
 
-    // Create metadata file for original gpx source
+    // Create metadata file for original kml source
     var metadatafile = path.join(outdirectory, '/metadata.json');
     digest(infile, function(err, metadata) {
       fs.writeFile(metadatafile, JSON.stringify(metadata), function(err) {
-        createIndices();
-        if (err) return callback(err);
-        return archiveOriginal(callback);
+        if (err) throw err;
+        createIndices(function(err) {
+          if (err) throw err;
+          archiveOriginal(function(err) {
+            if (err) throw err;
+            return callback(err);
+          });
+        });
       });
     });
 
@@ -132,6 +137,7 @@ module.exports = function(infile, outdirectory, callback) {
 
       q.awaitAll(function(err) {
         if (err) return callback(err);
+        return callback();
       });
     }
 

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -75,7 +75,7 @@ test('[GPX togeojson] convert, index, and archive valid GPX', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original gpx');
       assert.ok(fs.existsSync(path.join(outdir, 'archived.gpx')), 'original file archived');
-      assert.deepEqual(originalfile, archivedfile, 'file contents are the same');
+      assert.equal(originalfile.compare(archivedfile), 0, 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -61,7 +61,7 @@ test('[GPX togeojson] fails empty features only', function(assert) {
   });
 });
 
-test.only('[GPX togeojson] convert and index valid GPX', function(assert) {
+test('[GPX togeojson] convert, index, and archive valid GPX', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'gpx', 'ok-valid-file.gpx');
   togeojson.index_worthy_size = 100; // 100 bytes
 

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -61,7 +61,7 @@ test('[GPX togeojson] fails empty features only', function(assert) {
   });
 });
 
-test.only('[GPX togeojson] convert, index, and archive valid GPX', function(assert) {
+test('[GPX togeojson] convert, index, and archive valid GPX', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'gpx', 'ok-valid-file.gpx');
   togeojson.index_worthy_size = 100; // 100 bytes
 

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -61,19 +61,21 @@ test('[GPX togeojson] fails empty features only', function(assert) {
   });
 });
 
-test('[GPX togeojson] convert, index, and archive valid GPX', function(assert) {
+test.only('[GPX togeojson] convert, index, and archive valid GPX', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'gpx', 'ok-valid-file.gpx');
   togeojson.index_worthy_size = 100; // 100 bytes
 
   tmpdir(function(err, outdir) {
     togeojson(infile, outdir, function(err) {
+      var originalfile = fs.readFileSync(infile);
+      var archivedfile = fs.readFileSync(path.join(outdir, 'archived.gpx'));
       if (err) throw err;
       assert.ifError(err, 'no error');
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original gpx');
       assert.ok(fs.existsSync(path.join(outdir, 'archived.gpx')), 'original file archived');
-      assert.equal(fs.readFile(infile) === fs.readFile(path.join(outdir, 'archived.gpx')), true, 'file contents are the same');
+      assert.deepEqual(originalfile, archivedfile, 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-gpx.test.js
+++ b/test/togeojson-gpx.test.js
@@ -61,7 +61,7 @@ test('[GPX togeojson] fails empty features only', function(assert) {
   });
 });
 
-test('[GPX togeojson] convert and index valid GPX', function(assert) {
+test.only('[GPX togeojson] convert and index valid GPX', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'gpx', 'ok-valid-file.gpx');
   togeojson.index_worthy_size = 100; // 100 bytes
 
@@ -72,10 +72,11 @@ test('[GPX togeojson] convert and index valid GPX', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'tracks.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original gpx');
+      assert.ok(fs.existsSync(path.join(outdir, 'archived.gpx')), 'original file archived');
+      assert.equal(fs.readFile(infile) === fs.readFile(path.join(outdir, 'archived.gpx')), true, 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });
     });
   });
 });
-

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -90,7 +90,7 @@ test('[KML togeojson] fails empty features only', function(assert) {
   });
 });
 
-test('[KML togeojson] convert and index valid kml', function(assert) {
+test('[KML togeojson] convert, index, and archive valid kml', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-layers-folders-emptygeometries.kml');
   togeojson.index_worthy_size = 100; // 100 bytes
 

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -90,7 +90,7 @@ test('[KML togeojson] fails empty features only', function(assert) {
   });
 });
 
-test('[KML togeojson] convert and index valid kml', function(assert) {
+test.only('[KML togeojson] convert and index valid kml', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-layers-folders-emptygeometries.kml');
   togeojson.index_worthy_size = 100; // 100 bytes
 
@@ -106,7 +106,7 @@ test('[KML togeojson] convert and index valid kml', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
-      assert.ok(fs.existsSync(path.join(outdir, infile)), 'original file retained');
+      assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file retained');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -90,7 +90,7 @@ test('[KML togeojson] fails empty features only', function(assert) {
   });
 });
 
-test.only('[KML togeojson] convert, index, and archive valid kml', function(assert) {
+test('[KML togeojson] convert, index, and archive valid kml', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-layers-folders-emptygeometries.kml');
   togeojson.index_worthy_size = 100; // 100 bytes
 

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -90,7 +90,7 @@ test('[KML togeojson] fails empty features only', function(assert) {
   });
 });
 
-test('[KML togeojson] convert, index, and archive valid kml', function(assert) {
+test.only('[KML togeojson] convert, index, and archive valid kml', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-layers-folders-emptygeometries.kml');
   togeojson.index_worthy_size = 100; // 100 bytes
 
@@ -107,7 +107,7 @@ test('[KML togeojson] convert, index, and archive valid kml', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
       assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file archived');
-      assert.equal(fs.readFile(infile) === fs.readFile(path.join(outdir, 'archived.kml')), true, 'file contents are the same');
+      assert.equal(togeojson.fileInsides === fs.readFile(path.join(outdir, 'archived.kml')), true, 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -106,6 +106,7 @@ test('[KML togeojson] convert and index valid kml', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
+      assert.ok(fs.existsSync(path.join(outdir, infile)), 'original file retained');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -109,7 +109,7 @@ test.only('[KML togeojson] convert, index, and archive valid kml', function(asse
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
       assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file archived');
-      assert.equal(originalfile.compare(archivedfile), 0 , 'file contents are the same');
+      assert.equal(originalfile.compare(archivedfile), 0, 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -90,7 +90,7 @@ test('[KML togeojson] fails empty features only', function(assert) {
   });
 });
 
-test('[KML togeojson] convert, index, and archive valid kml', function(assert) {
+test.only('[KML togeojson] convert, index, and archive valid kml', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-layers-folders-emptygeometries.kml');
   togeojson.index_worthy_size = 100; // 100 bytes
 
@@ -109,7 +109,7 @@ test('[KML togeojson] convert, index, and archive valid kml', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
       assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file archived');
-      assert.deepEqual(originalfile, archivedfile, 'file contents are the same');
+      assert.equal(originalfile.compare(archivedfile), 0 , 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -96,6 +96,8 @@ test.only('[KML togeojson] convert, index, and archive valid kml', function(asse
 
   tmpdir(function(err, outdir) {
     togeojson(infile, outdir, function(err) {
+      var originalfile = fs.readFileSync(infile);
+      var archivedfile = fs.readFileSync(path.join(outdir, 'archived.kml'));
       assert.ifError(err, 'no error');
       assert.ok(fs.existsSync(path.join(outdir, 'folder-01-01.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'folder-01-01.geojson.index')), 'created index');
@@ -107,8 +109,7 @@ test.only('[KML togeojson] convert, index, and archive valid kml', function(asse
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
       assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file archived');
-      assert.equal(togeojson.infileContents === fs.readFileSync(path.join(outdir, 'archived.kml')), true, 'file contents are the same');
-      console.log(fs.readFileSync(path.join(outdir, 'archived.kml')));
+      assert.deepEqual(originalfile, archivedfile, 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -90,7 +90,7 @@ test('[KML togeojson] fails empty features only', function(assert) {
   });
 });
 
-test.only('[KML togeojson] convert and index valid kml', function(assert) {
+test('[KML togeojson] convert and index valid kml', function(assert) {
   var infile = path.resolve(__dirname, 'fixtures', 'kml', 'ok-layers-folders-emptygeometries.kml');
   togeojson.index_worthy_size = 100; // 100 bytes
 
@@ -106,7 +106,8 @@ test.only('[KML togeojson] convert and index valid kml', function(assert) {
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson')), 'converted layer');
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
-      assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file retained');
+      assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file archived');
+      assert.equal(fs.readFile(infile) === fs.readFile(path.join(outdir, 'archived.kml')), true, 'file contents are the same');
       rimraf(outdir, function(err) {
         assert.end(err);
       });

--- a/test/togeojson-kml.test.js
+++ b/test/togeojson-kml.test.js
@@ -107,7 +107,8 @@ test.only('[KML togeojson] convert, index, and archive valid kml', function(asse
       assert.ok(fs.existsSync(path.join(outdir, 'my-test.geojson.index')), 'created index');
       assert.ok(fs.existsSync(path.join(outdir, 'metadata.json')), 'added metadata of original kml');
       assert.ok(fs.existsSync(path.join(outdir, 'archived.kml')), 'original file archived');
-      assert.equal(togeojson.fileInsides === fs.readFile(path.join(outdir, 'archived.kml')), true, 'file contents are the same');
+      assert.equal(togeojson.infileContents === fs.readFileSync(path.join(outdir, 'archived.kml')), true, 'file contents are the same');
+      console.log(fs.readFileSync(path.join(outdir, 'archived.kml')));
       rimraf(outdir, function(err) {
         assert.end(err);
       });


### PR DESCRIPTION
This PR adds steps to retain/archive the original KML or GPX file uploaded by a user.

Additionally, I added tests which assert:
* that the archived file is created in the outdirectory
* that the contents of the original infile match the contents of the archived file

@GretaCB Two questions I have are:
- Should `digest` be run against the infile before writing the contents to `archived.*` or does that create a file different from the **original** file?
- Should a random string of integers be added to the  `archive.*` filename to differentiate between multiple archived files, or are individual outdirectories created per upload?

cc @mapbox/unpacker 