### PR TITLE
Split tiffs into larger parts

### DIFF
--- a/parts/bySize.js
+++ b/parts/bySize.js
@@ -10,7 +10,7 @@ module.exports = function splitBySize(filepath, info, callback) {
   } else if (untiled.indexOf(info.filetype) !== -1) {
     callback(null, Math.min(max, Math.ceil(mb / 10)));
   } else if (raster.indexOf(info.filetype) !== -1) {
-    callback(null, Math.min(max, Math.ceil(mb / 500)));
+    callback(null, Math.min(max, Math.ceil(mb / 1500)));
   } else {
     callback(null, 1);
   }

--- a/test/bySize.test.js
+++ b/test/bySize.test.js
@@ -190,9 +190,9 @@ test('[parts bySize] csv split per 10MB', function(assert) {
   });
 });
 
-test('[parts bySize] tif split per 10MB', function(assert) {
-  var mbs = 25;
-  var expected = Math.ceil(mbs / 100);
+test('[parts bySize] tif split per 1.5GB', function(assert) {
+  var mbs = 1500;
+  var expected = Math.ceil(mbs / 1500);
   var info = {
     size: mbs * 1024 * 1024,
     filetype: 'tif'


### PR DESCRIPTION
Use less workers, use more CPU power!

This splits tiffs into 1.5GB chunks o_O instead of 500MB

cc @mapsam @jacquestardie @rclark 