### PR TITLE
Handle reprojection errors from node-wmtiff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 preprocessors/test*
 test/fixtures/*.aux.xml
+.DS_Store

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,14 @@
+# Contributing
+
+General guidelines for contributing to preprocessorcerer. 
+
+## Releasing
+
+To release a new preprocessorcerer version:
+
+ - Make sure that all tests as passing (including travis tests).
+ - Update the CHANGELOG.md
+ - Make a "bump commit" by updating the version in `package.json` and adding a commit like `-m "bump to v0.8.5"`
+ - Create a github tag like `git tag -a v0.8.5 -m "v0.8.5" && git push --tags`
+ - Ensure travis tests are passing
+ - Then publish the module to npm repositories by running `npm publish`

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "split": "^1.0.0",
     "srs": "~1.2.0",
     "wmshp": "~0.4.0",
-    "wmtiff": "~0.4.0"
+    "wmtiff": "~0.4.1"
   },
   "jshintConfig": {
     "node": true,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "split": "^1.0.0",
     "srs": "~1.2.0",
     "wmshp": "~0.4.0",
-    "wmtiff": "https://mapbox-npm.s3.amazonaws.com/package/wmtiff-v0.4.0-1-ge6c957b-0813eb808d7b90c233fec3dc5d3e0b87fc15d389.tgz"
+    "wmtiff": "~0.4.0"
   },
   "jshintConfig": {
     "node": true,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "split": "^1.0.0",
     "srs": "~1.2.0",
     "wmshp": "~0.4.0",
-    "wmtiff": "~0.4.0"
+    "wmtiff": "https://mapbox-npm.s3.amazonaws.com/package/wmtiff-v0.4.0-1-ge6c957b-0813eb808d7b90c233fec3dc5d3e0b87fc15d389.tgz"
   },
   "jshintConfig": {
     "node": true,

--- a/preprocessors/tif-reproject.preprocessor.js
+++ b/preprocessors/tif-reproject.preprocessor.js
@@ -5,7 +5,7 @@ var wmtiff = require('wmtiff').reproject;
 module.exports = function(infile, outfile, callback) {
   try { wmtiff(infile, outfile); }
   catch (err) { 
-    if (err.message === 'GDAL Reprojection Error') {
+    if (err.message.indexOf('GDAL Reprojection Error') > -1) {
       err.message = 'Unable to reproject data. Please reproject to Web Mercator (EPSG:3857) and try again.';
       err.code = 'EINVALID';
     }

--- a/preprocessors/tif-reproject.preprocessor.js
+++ b/preprocessors/tif-reproject.preprocessor.js
@@ -4,8 +4,13 @@ var wmtiff = require('wmtiff').reproject;
 
 module.exports = function(infile, outfile, callback) {
   try { wmtiff(infile, outfile); }
-  catch (err) { return callback(err); }
-
+  catch (err) { 
+    if (err.message === 'GDAL Reprojection Error') {
+      err.message = 'Unable to reproject data. Please reproject to Web Mercator (EPSG:3857) and try again.';
+      err.code = 'EINVALID';
+    }
+    return callback(err);
+  }
   callback();
 };
 

--- a/test/tif-reproject.test.js
+++ b/test/tif-reproject.test.js
@@ -9,6 +9,7 @@ var sphericalMerc = path.resolve(__dirname, 'fixtures', 'spherical-merc.tif');
 var esriMerc = path.resolve(__dirname, 'fixtures', 'web-merc-aux-sphere.tif');
 var wgs84 = path.resolve(__dirname, 'fixtures', 'wgs84.tif');
 var geojson = path.resolve(__dirname, 'fixtures', 'valid.geojson');
+var invalidReprojection = path.resolve(__dirname, 'fixtures', 'invalid-reprojection.tif');
 var gdal = require('gdal');
 
 test('[tif-reproject] criteria: not a tif', function(assert) {
@@ -51,15 +52,11 @@ test('[tif-reproject] criteria: in epsg:4326', function(assert) {
   });
 });
 
-test('[tif-reproject] reprojection: to epsg:3857', function(assert) {
+test('[tif-reproject] invalid reprojection: to epsg:3857', function(assert) {
   var outfile = path.join(os.tmpdir(), crypto.randomBytes(8).toString('hex'));
-  reproject(wgs84, outfile, function(err) {
-    assert.ifError(err, 'no error');
-    var ds = gdal.open(outfile);
-    assert.ok(ds.srs.isSame(gdal.SpatialReference.fromEPSG(3857)), 'reprojected correctly');
-    ds.close();
-    ds = null;
-    fs.unlinkSync(outfile);
+  reproject(invalidReprojection, outfile, function(err) {
+    assert.equal(err.code, 'EINVALID');
+    assert.equal(err.message, 'Unable to reproject data. Please reproject to Web Mercator (EPSG:3857) and try again.');
     assert.end();
   });
 });

--- a/test/tif-reproject.test.js
+++ b/test/tif-reproject.test.js
@@ -1,7 +1,6 @@
 var test = require('tape');
 var reproject = require('../preprocessors/tif-reproject.preprocessor');
 var os = require('os');
-var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var googleMerc = path.resolve(__dirname, 'fixtures', 'google-merc.tif');
@@ -10,7 +9,6 @@ var esriMerc = path.resolve(__dirname, 'fixtures', 'web-merc-aux-sphere.tif');
 var wgs84 = path.resolve(__dirname, 'fixtures', 'wgs84.tif');
 var geojson = path.resolve(__dirname, 'fixtures', 'valid.geojson');
 var invalidReprojection = path.resolve(__dirname, 'fixtures', 'invalid-reprojection.tif');
-var gdal = require('gdal');
 
 test('[tif-reproject] criteria: not a tif', function(assert) {
   reproject.criteria(geojson, { filetype: 'geojson' }, function(err, process) {


### PR DESCRIPTION
Assigns exit code 3 `EINVALID` to GDAL reprojection errors so they can be handled by watchbot. See https://github.com/mapbox/unpacker/issues/1507