### PR TITLE
Bump to 1.0.0, mapnik to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0
+
+- Update to mapnik-omnivore@9.0.0
+- Update to mapnik@3.7.0
+- Drops windows support
+
 ## 0.18.0
 
 - Update mapnik-omnivore@8.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/preprocessorcerer",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -33,11 +33,11 @@
   },
   "dependencies": {
     "@mapbox/mapbox-file-sniff": "~1.0.0",
-    "@mapbox/mapnik-omnivore": "~8.5.0",
+    "@mapbox/mapnik-omnivore": "~8.6.0",
     "@mapbox/mbtiles": "~0.9.0",
     "bytetiff": "~0.5.0",
     "gdal": "~0.9.3",
-    "mapnik": "~3.6.0",
+    "mapnik": "~3.7.0",
     "mkdirp": "^0.5.0",
     "queue-async": "^1.0.7",
     "split": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/preprocessorcerer",
-  "version": "0.19.0",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@mapbox/mapbox-file-sniff": "~1.0.0",
-    "@mapbox/mapnik-omnivore": "~8.6.0",
+    "@mapbox/mapnik-omnivore": "~9.0.0",
     "@mapbox/mbtiles": "~0.9.0",
     "bytetiff": "~0.5.0",
     "gdal": "~0.9.3",


### PR DESCRIPTION
Bumping major version due to dropping of windows support (which I think is never used) but I feel like incase others are depending on this it will prevent an automatic update. Updated to new version of mapnik-omnivore and mapnik. 